### PR TITLE
feat : notification mvp

### DIFF
--- a/common/src/main/java/com/team15gijo/common/exception/GlobalExceptionHandler.java
+++ b/common/src/main/java/com/team15gijo/common/exception/GlobalExceptionHandler.java
@@ -61,11 +61,11 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
                 .body(ApiResponse.exception(errorMessage, CommonExceptionCode.VALIDATION_FAILED));
     }
 
-    @ExceptionHandler(AsyncRequestTimeoutException.class)
-    public Mono<ResponseEntity<ApiResponse<?>>> handleAsyncTimeoutException(AsyncRequestTimeoutException e) {
-        log.warn("AsyncRequestTimeoutException : ", e);
-        return Mono.just(handleExceptionInternal(CommonExceptionCode.REQUEST_TIMEOUT));
-    }
+//    @ExceptionHandler(AsyncRequestTimeoutException.class)
+//    public Mono<ResponseEntity<ApiResponse<?>>> handleAsyncTimeoutException(AsyncRequestTimeoutException e) {
+//        log.warn("AsyncRequestTimeoutException : ", e);
+//        return Mono.just(handleExceptionInternal(CommonExceptionCode.REQUEST_TIMEOUT));
+//    }
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ApiResponse<?>> handleException(Exception e) {

--- a/notification/.env
+++ b/notification/.env
@@ -1,4 +1,0 @@
-SPRING_DATASOURCE_URL=jdbc:postgresql://localhost:5433/your_database
-SPRING_DATASOURCE_USERNAME=your_username
-SPRING_DATASOURCE_PASSWORD=test1234
-SPRING_DATASOURCE_PLATFORM=org.hibernate.dialect.PostgreSQLDialect

--- a/notification/.gitignore
+++ b/notification/.gitignore
@@ -35,3 +35,4 @@ out/
 
 ### VS Code ###
 .vscode/
+.env

--- a/notification/src/main/java/com/team15gijo/notification/NotificationApplicationKafkaConfig.java
+++ b/notification/src/main/java/com/team15gijo/notification/NotificationApplicationKafkaConfig.java
@@ -1,5 +1,8 @@
 package com.team15gijo.notification;
 
+import com.team15gijo.notification.application.dto.v1.message.ChatNotificationEventDto;
+import com.team15gijo.notification.application.dto.v1.message.CommentNotificationEventDto;
+import com.team15gijo.notification.application.dto.v1.message.FollowNotificationEventDto;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
@@ -26,18 +29,63 @@ public class NotificationApplicationKafkaConfig {
      *  Kafka Producer Config
      *
      */
-    @Bean
-    public KafkaTemplate<String, String> kafkaTemplate() {
-        return new KafkaTemplate<>(producerFactory());
-    }
+//    @Bean
+//    public KafkaTemplate<String, String> kafkaTemplate() {
+//        return new KafkaTemplate<>(producerFactory());
+//    }
+//
+//    @Bean
+//    public ProducerFactory<String, String> producerFactory() {
+//        Map<String, Object> configProps = new HashMap<>();
+//        configProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+//        configProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+//        configProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+//        return new DefaultKafkaProducerFactory<>(configProps);
+//    }
 
+    // 댓글 이벤트용 KafkaTemplate(테스트 용으로 나눈 코드, 각자 서버에서는 위의 코드를 참고)
     @Bean
-    public ProducerFactory<String, String> producerFactory() {
+    public ProducerFactory<String, CommentNotificationEventDto> commentProducerFactory() {
         Map<String, Object> configProps = new HashMap<>();
         configProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
         configProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
         configProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
         return new DefaultKafkaProducerFactory<>(configProps);
+    }
+
+    @Bean
+    public KafkaTemplate<String, CommentNotificationEventDto> commentKafkaTemplate() {
+        return new KafkaTemplate<>(commentProducerFactory());
+    }
+
+    // 팔로우 이벤트용 KafkaTemplate(테스트 용으로 나눈 코드, 각자 서버에서는 위의 코드를 참고)
+    @Bean
+    public ProducerFactory<String, FollowNotificationEventDto> followProducerFactory() {
+        Map<String, Object> configProps = new HashMap<>();
+        configProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        configProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        configProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+        return new DefaultKafkaProducerFactory<>(configProps);
+    }
+
+    @Bean
+    public KafkaTemplate<String, FollowNotificationEventDto> followKafkaTemplate() {
+        return new KafkaTemplate<>(followProducerFactory());
+    }
+
+    // 채팅 이벤트용 KafkaTemplate(테스트 용으로 나눈 코드, 각자 서버에서는 위의 코드를 참고)
+    @Bean
+    public ProducerFactory<String, ChatNotificationEventDto> chatProducerFactory() {
+        Map<String, Object> configProps = new HashMap<>();
+        configProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        configProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        configProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+        return new DefaultKafkaProducerFactory<>(configProps);
+    }
+
+    @Bean
+    public KafkaTemplate<String, ChatNotificationEventDto> chatKafkaTemplate() {
+        return new KafkaTemplate<>(chatProducerFactory());
     }
 
 

--- a/notification/src/main/java/com/team15gijo/notification/NotificationApplicationKafkaConfig.java
+++ b/notification/src/main/java/com/team15gijo/notification/NotificationApplicationKafkaConfig.java
@@ -1,6 +1,5 @@
 package com.team15gijo.notification;
 
-import com.team15gijo.notification.application.dto.v1.CommentNotificationEvent;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
@@ -23,6 +22,10 @@ import org.springframework.kafka.support.serializer.JsonSerializer;
 @Configuration
 public class NotificationApplicationKafkaConfig {
 
+    /**
+     *  Kafka Producer Config
+     *
+     */
     @Bean
     public KafkaTemplate<String, String> kafkaTemplate() {
         return new KafkaTemplate<>(producerFactory());
@@ -37,6 +40,11 @@ public class NotificationApplicationKafkaConfig {
         return new DefaultKafkaProducerFactory<>(configProps);
     }
 
+
+    /**
+     *  Kafka Consumer Config
+     *
+     */
     @Bean
     public ConsumerFactory<String, String> consumerFactory() {
         Map<String, Object> configProps = new HashMap<>();                                     // 컨슈머 팩토리 설정을 위한 맵을 생성.
@@ -44,7 +52,7 @@ public class NotificationApplicationKafkaConfig {
         configProps.put(ConsumerConfig.GROUP_ID_CONFIG, "notification-service");
         configProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);     // 메시지 키의 디시리얼라이저 클래스를 설정.
         configProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);      // 메시지 값의 디시리얼라이저 클래스를 설정.
-        configProps.put(JsonDeserializer.TRUSTED_PACKAGES, "*");
+        configProps.put(JsonDeserializer.TRUSTED_PACKAGES, "*");                   // 역직렬화할 때 data 신뢰성 모두 허용
         return new DefaultKafkaConsumerFactory<>(configProps);                                     // 설정된 프로퍼티로 DefaultKafkaConsumerFactory를 생성하여 반환.
     }
 

--- a/notification/src/main/java/com/team15gijo/notification/NotificationApplicationKafkaConfig.java
+++ b/notification/src/main/java/com/team15gijo/notification/NotificationApplicationKafkaConfig.java
@@ -1,28 +1,53 @@
 package com.team15gijo.notification;
 
+import com.team15gijo.notification.application.dto.v1.CommentNotificationEvent;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.kafka.annotation.EnableKafka;
 import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
 import org.springframework.kafka.core.ConsumerFactory;
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+import org.springframework.kafka.support.serializer.JsonSerializer;
 
 @EnableKafka
 @Configuration
 public class NotificationApplicationKafkaConfig {
 
     @Bean
+    public KafkaTemplate<String, String> kafkaTemplate() {
+        return new KafkaTemplate<>(producerFactory());
+    }
+
+    @Bean
+    public ProducerFactory<String, String> producerFactory() {
+        Map<String, Object> configProps = new HashMap<>();
+        configProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        configProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        configProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+        return new DefaultKafkaProducerFactory<>(configProps);
+    }
+
+    @Bean
     public ConsumerFactory<String, String> consumerFactory() {
         Map<String, Object> configProps = new HashMap<>();                                     // 컨슈머 팩토리 설정을 위한 맵을 생성.
         configProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");              // Kafka 브로커의 주소를 설정.
+        configProps.put(ConsumerConfig.GROUP_ID_CONFIG, "notification-service");
         configProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);     // 메시지 키의 디시리얼라이저 클래스를 설정.
-        configProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);      // 메시지 값의 디시리얼라이저 클래스를 설정.
+        configProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);      // 메시지 값의 디시리얼라이저 클래스를 설정.
+        configProps.put(JsonDeserializer.TRUSTED_PACKAGES, "*");
         return new DefaultKafkaConsumerFactory<>(configProps);                                     // 설정된 프로퍼티로 DefaultKafkaConsumerFactory를 생성하여 반환.
     }
+
 
     @Bean
     public ConcurrentKafkaListenerContainerFactory<String, String> kafkaListenerContainerFactory() {

--- a/notification/src/main/java/com/team15gijo/notification/application/consumer/CommentNotificationConsumer.java
+++ b/notification/src/main/java/com/team15gijo/notification/application/consumer/CommentNotificationConsumer.java
@@ -1,0 +1,48 @@
+package com.team15gijo.notification.application.consumer;
+
+import com.team15gijo.notification.application.dto.v1.CommentNotificationEvent;
+import com.team15gijo.notification.application.service.v1.EmitterService;
+import com.team15gijo.notification.domain.model.Notification;
+import com.team15gijo.notification.domain.model.NotificationType;
+import com.team15gijo.notification.domain.repository.NotificationRepository;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CommentNotificationConsumer {
+
+    private final NotificationRepository notificationRepository;
+    private final EmitterService emitterService;
+
+    @KafkaListener(topics = "COMMENT", groupId = "notification-service")
+    public void commentConsumer(CommentNotificationEvent event) {
+
+        Long receiverId = event.getReceiverId();
+        String nickname = event.getNickname();
+        String comment = event.getCommentContent();
+        String eventId = receiverId + "_" + System.currentTimeMillis();
+        String content = String.format("%s님이 '%s' 댓글을 작성하였습니다.", nickname, comment);
+
+
+        // 1. 알림 DB 저장
+        Notification notification = Notification.createNotification(receiverId, NotificationType.COMMENT, content, eventId);
+
+        notificationRepository.save(notification);
+
+        // 2. SSE로 사용자에게 전송
+        emitterService.send(
+                receiverId,
+                NotificationType.COMMENT,
+                content,
+                eventId,
+                notification.getNotificationId()
+        );
+
+    }
+
+}

--- a/notification/src/main/java/com/team15gijo/notification/application/dto/v1/CommentNotificationEvent.java
+++ b/notification/src/main/java/com/team15gijo/notification/application/dto/v1/CommentNotificationEvent.java
@@ -1,0 +1,14 @@
+package com.team15gijo.notification.application.dto.v1;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CommentNotificationEvent {
+    private Long receiverId;         // 알림 받을 사용자 ID
+    private String nickname;           // 알림을 보내는 사용자의 닉네임
+    private String commentContent;
+}

--- a/notification/src/main/java/com/team15gijo/notification/application/dto/v1/NotificationResponseDto.java
+++ b/notification/src/main/java/com/team15gijo/notification/application/dto/v1/NotificationResponseDto.java
@@ -1,0 +1,30 @@
+package com.team15gijo.notification.application.dto.v1;
+
+import com.team15gijo.notification.domain.model.Notification;
+import com.team15gijo.notification.domain.model.NotificationType;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class NotificationResponseDto {
+
+    private UUID notificationId;
+    private NotificationType notificationType;
+    private String notificationContent;
+    private String eventId;
+
+    public static NotificationResponseDto fromEntity(Notification notification) {
+        return NotificationResponseDto.builder()
+                .notificationId(notification.getNotificationId())
+                .notificationType(notification.getNotificationType())
+                .notificationContent(notification.getNotificationContent())
+                .eventId(notification.getEventId())
+                .build();
+    }
+}

--- a/notification/src/main/java/com/team15gijo/notification/application/dto/v1/message/ChatNotificationEventDto.java
+++ b/notification/src/main/java/com/team15gijo/notification/application/dto/v1/message/ChatNotificationEventDto.java
@@ -1,0 +1,13 @@
+package com.team15gijo.notification.application.dto.v1.message;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChatNotificationEventDto {
+    private Long receiverId;         // 알림 받을 사용자 ID
+    private String nickname;           // 알림을 보내는 사용자의 닉네임
+}

--- a/notification/src/main/java/com/team15gijo/notification/application/dto/v1/message/CommentNotificationEventDto.java
+++ b/notification/src/main/java/com/team15gijo/notification/application/dto/v1/message/CommentNotificationEventDto.java
@@ -1,4 +1,4 @@
-package com.team15gijo.notification.application.dto.v1;
+package com.team15gijo.notification.application.dto.v1.message;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -7,7 +7,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-public class CommentNotificationEvent {
+public class CommentNotificationEventDto {
     private Long receiverId;         // 알림 받을 사용자 ID
     private String nickname;           // 알림을 보내는 사용자의 닉네임
     private String commentContent;

--- a/notification/src/main/java/com/team15gijo/notification/application/dto/v1/message/FollowNotificationEventDto.java
+++ b/notification/src/main/java/com/team15gijo/notification/application/dto/v1/message/FollowNotificationEventDto.java
@@ -1,0 +1,13 @@
+package com.team15gijo.notification.application.dto.v1.message;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class FollowNotificationEventDto {
+    private Long receiverId;         // 알림 받을 사용자 ID
+    private String nickname;           // 알림을 보내는 사용자의 닉네임
+}

--- a/notification/src/main/java/com/team15gijo/notification/application/message/CommentNotificationConsumer.java
+++ b/notification/src/main/java/com/team15gijo/notification/application/message/CommentNotificationConsumer.java
@@ -1,15 +1,15 @@
-package com.team15gijo.notification.application.consumer;
+package com.team15gijo.notification.application.message;
 
 import com.team15gijo.notification.application.dto.v1.CommentNotificationEvent;
 import com.team15gijo.notification.application.service.v1.EmitterService;
 import com.team15gijo.notification.domain.model.Notification;
 import com.team15gijo.notification.domain.model.NotificationType;
 import com.team15gijo.notification.domain.repository.NotificationRepository;
-import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
@@ -19,9 +19,11 @@ public class CommentNotificationConsumer {
     private final NotificationRepository notificationRepository;
     private final EmitterService emitterService;
 
-    @KafkaListener(topics = "COMMENT", groupId = "notification-service")
+    @KafkaListener(topics = "COMMENT", groupId = "notification-service", containerFactory = "kafkaListenerContainerFactory")
+    @Transactional
     public void commentConsumer(CommentNotificationEvent event) {
-
+        System.out.println("📩 받은 Kafka 메시지: " + event);
+        log.info("📨 Kafka COMMENT 메시지 수신: {}", event);
         Long receiverId = event.getReceiverId();
         String nickname = event.getNickname();
         String comment = event.getCommentContent();

--- a/notification/src/main/java/com/team15gijo/notification/application/message/CommentNotificationConsumer.java
+++ b/notification/src/main/java/com/team15gijo/notification/application/message/CommentNotificationConsumer.java
@@ -1,6 +1,6 @@
 package com.team15gijo.notification.application.message;
 
-import com.team15gijo.notification.application.dto.v1.CommentNotificationEvent;
+import com.team15gijo.notification.application.dto.v1.message.CommentNotificationEventDto;
 import com.team15gijo.notification.application.service.v1.EmitterService;
 import com.team15gijo.notification.domain.model.Notification;
 import com.team15gijo.notification.domain.model.NotificationType;
@@ -21,7 +21,7 @@ public class CommentNotificationConsumer {
 
     @KafkaListener(topics = "COMMENT", groupId = "notification-service", containerFactory = "kafkaListenerContainerFactory")
     @Transactional
-    public void commentConsumer(CommentNotificationEvent event) {
+    public void commentConsumer(CommentNotificationEventDto event) {
         System.out.println("📩 받은 Kafka 메시지: " + event);
         log.info("📨 Kafka COMMENT 메시지 수신: {}", event);
         Long receiverId = event.getReceiverId();

--- a/notification/src/main/java/com/team15gijo/notification/application/message/CommentNotificationConsumer.java
+++ b/notification/src/main/java/com/team15gijo/notification/application/message/CommentNotificationConsumer.java
@@ -1,6 +1,8 @@
 package com.team15gijo.notification.application.message;
 
+import com.team15gijo.notification.application.dto.v1.message.ChatNotificationEventDto;
 import com.team15gijo.notification.application.dto.v1.message.CommentNotificationEventDto;
+import com.team15gijo.notification.application.dto.v1.message.FollowNotificationEventDto;
 import com.team15gijo.notification.application.service.v1.EmitterService;
 import com.team15gijo.notification.domain.model.Notification;
 import com.team15gijo.notification.domain.model.NotificationType;
@@ -27,7 +29,7 @@ public class CommentNotificationConsumer {
         Long receiverId = event.getReceiverId();
         String nickname = event.getNickname();
         String comment = event.getCommentContent();
-        String eventId = receiverId + "_" + System.currentTimeMillis();
+        String eventId = receiverId + "_" + System.currentTimeMillis() + "_comment";
         String content = String.format("%s님이 '%s' 댓글을 작성하였습니다.", nickname, comment);
 
 
@@ -44,7 +46,58 @@ public class CommentNotificationConsumer {
                 eventId,
                 notification.getNotificationId()
         );
+    }
 
+    @KafkaListener(topics = "FOLLOW", groupId = "notification-service", containerFactory = "kafkaListenerContainerFactory")
+    @Transactional
+    public void followConsumer(FollowNotificationEventDto event) {
+        System.out.println("📩 받은 Kafka 메시지: " + event);
+        log.info("📨 Kafka COMMENT 메시지 수신: {}", event);
+        Long receiverId = event.getReceiverId();
+        String nickname = event.getNickname();
+        String eventId = receiverId + "_" + System.currentTimeMillis() + "_follow";
+        String content = String.format("%s님이 당신을 팔로우하였습니다.", nickname);
+
+
+        // 1. 알림 DB 저장
+        Notification notification = Notification.createNotification(receiverId, NotificationType.FOLLOW, content, eventId);
+
+        notificationRepository.save(notification);
+
+        // 2. SSE로 사용자에게 전송
+        emitterService.send(
+                receiverId,
+                NotificationType.FOLLOW,
+                content,
+                eventId,
+                notification.getNotificationId()
+        );
+    }
+
+    @KafkaListener(topics = "CHAT", groupId = "notification-service", containerFactory = "kafkaListenerContainerFactory")
+    @Transactional
+    public void chatConsumer(ChatNotificationEventDto event) {
+        System.out.println("📩 받은 Kafka 메시지: " + event);
+        log.info("📨 Kafka COMMENT 메시지 수신: {}", event);
+        Long receiverId = event.getReceiverId();
+        String nickname = event.getNickname();
+        String eventId = receiverId + "_" + System.currentTimeMillis() + "_chat";
+        String content = String.format("%s님이 채팅을 보냈습니다.", nickname);
+
+
+        // 1. 알림 DB 저장
+        Notification notification = Notification.createNotification(receiverId, NotificationType.CHAT, content, eventId);
+
+        notificationRepository.save(notification);
+
+        // 2. SSE로 사용자에게 전송
+        emitterService.send(
+                receiverId,
+                NotificationType.CHAT,
+                content,
+                eventId,
+                notification.getNotificationId()
+        );
     }
 
 }

--- a/notification/src/main/java/com/team15gijo/notification/application/message/KafkaTestProducer.java
+++ b/notification/src/main/java/com/team15gijo/notification/application/message/KafkaTestProducer.java
@@ -1,0 +1,20 @@
+package com.team15gijo.notification.application.message;
+
+import com.team15gijo.notification.application.dto.v1.CommentNotificationEvent;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+public class KafkaTestProducer {
+
+    private final KafkaTemplate<String, CommentNotificationEvent> kafkaTemplate;
+
+    public KafkaTestProducer(KafkaTemplate kafkaTemplate) {
+        this.kafkaTemplate = kafkaTemplate;
+    }
+
+    public void sendCommentCreate(CommentNotificationEvent event) {
+        kafkaTemplate.send("COMMENT", event);
+    }
+
+}

--- a/notification/src/main/java/com/team15gijo/notification/application/message/KafkaTestProducer.java
+++ b/notification/src/main/java/com/team15gijo/notification/application/message/KafkaTestProducer.java
@@ -1,20 +1,32 @@
 package com.team15gijo.notification.application.message;
 
+import com.team15gijo.notification.application.dto.v1.message.ChatNotificationEventDto;
 import com.team15gijo.notification.application.dto.v1.message.CommentNotificationEventDto;
+import com.team15gijo.notification.application.dto.v1.message.FollowNotificationEventDto;
+import lombok.RequiredArgsConstructor;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Service;
 
 @Service
+@RequiredArgsConstructor
 public class KafkaTestProducer {
 
-    private final KafkaTemplate<String, CommentNotificationEventDto> kafkaTemplate;
+    private final KafkaTemplate<String, CommentNotificationEventDto> commentKafkaTemplate;
+    private final KafkaTemplate<String, FollowNotificationEventDto> followKafkaTemplate;
+    private final KafkaTemplate<String, ChatNotificationEventDto> chatKafkaTemplate;
 
-    public KafkaTestProducer(KafkaTemplate kafkaTemplate) {
-        this.kafkaTemplate = kafkaTemplate;
-    }
+
 
     public void sendCommentCreate(CommentNotificationEventDto event) {
-        kafkaTemplate.send("COMMENT", event);
+        commentKafkaTemplate.send("COMMENT", event);
+    }
+
+    public void sendFollowCreate(FollowNotificationEventDto event) {
+        followKafkaTemplate.send("FOLLOW", event);
+    }
+
+    public void sendChatCreate(ChatNotificationEventDto event) {
+        chatKafkaTemplate.send("CHAT", event);
     }
 
 }

--- a/notification/src/main/java/com/team15gijo/notification/application/message/KafkaTestProducer.java
+++ b/notification/src/main/java/com/team15gijo/notification/application/message/KafkaTestProducer.java
@@ -1,19 +1,19 @@
 package com.team15gijo.notification.application.message;
 
-import com.team15gijo.notification.application.dto.v1.CommentNotificationEvent;
+import com.team15gijo.notification.application.dto.v1.message.CommentNotificationEventDto;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Service;
 
 @Service
 public class KafkaTestProducer {
 
-    private final KafkaTemplate<String, CommentNotificationEvent> kafkaTemplate;
+    private final KafkaTemplate<String, CommentNotificationEventDto> kafkaTemplate;
 
     public KafkaTestProducer(KafkaTemplate kafkaTemplate) {
         this.kafkaTemplate = kafkaTemplate;
     }
 
-    public void sendCommentCreate(CommentNotificationEvent event) {
+    public void sendCommentCreate(CommentNotificationEventDto event) {
         kafkaTemplate.send("COMMENT", event);
     }
 

--- a/notification/src/main/java/com/team15gijo/notification/application/service/v1/EmitterService.java
+++ b/notification/src/main/java/com/team15gijo/notification/application/service/v1/EmitterService.java
@@ -1,10 +1,66 @@
 package com.team15gijo.notification.application.service.v1;
 
+import com.team15gijo.notification.application.dto.v1.NotificationResponseDto;
+import com.team15gijo.notification.domain.model.NotificationStatus;
+import com.team15gijo.notification.domain.model.NotificationType;
+import com.team15gijo.notification.domain.repository.EmitterRepository;
+import java.io.IOException;
+import java.util.Map;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 @Service
 @RequiredArgsConstructor
 public class EmitterService {
+
+    private static final Long TIMEOUT = 60L * 1000 * 60; // 60분
+    private final EmitterRepository emitterRepository;
+
+    public SseEmitter subscribe(Long userId) {
+        String emitterId = userId + "_" + System.currentTimeMillis();
+        SseEmitter emitter = new SseEmitter(TIMEOUT);
+        emitterRepository.save(emitterId, emitter);
+
+        emitter.onCompletion(() -> emitterRepository.deleteById(emitterId));
+        emitter.onTimeout(() -> {
+            emitter.complete();
+            emitterRepository.deleteById(emitterId);
+        });
+
+        try {
+            emitter.send(SseEmitter.event()
+                    .id(emitterId)
+                    .name(NotificationStatus.CONNECT.name())
+                    .data("connected"));
+        } catch (IOException e) {
+            emitter.completeWithError(e);
+        }
+
+        return emitter;
+    }
+
+    public void send(Long receiverId, NotificationType type, String content, String eventId, UUID notificationId) {
+        NotificationResponseDto response = NotificationResponseDto.builder()
+                .notificationId(notificationId)
+                .notificationType(type)
+                .notificationContent(content)
+                .eventId(eventId)
+                .build();
+
+        Map<String, SseEmitter> emitters = emitterRepository.findAllByUserId(receiverId);
+        emitters.forEach((emitterId, emitter) -> {
+            try {
+                emitter.send(SseEmitter.event()
+                        .id(eventId)
+                        .name(NotificationStatus.NEW.name())
+                        .data(response));
+            } catch (IOException e) {
+                emitter.complete();
+                emitterRepository.deleteById(emitterId);
+            }
+        });
+    }
 
 }

--- a/notification/src/main/java/com/team15gijo/notification/application/service/v1/EmitterService.java
+++ b/notification/src/main/java/com/team15gijo/notification/application/service/v1/EmitterService.java
@@ -8,11 +8,13 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class EmitterService {
 
     private static final Long TIMEOUT = 60L * 1000 * 60; // 60분
@@ -42,6 +44,7 @@ public class EmitterService {
     }
 
     public void send(Long receiverId, NotificationType type, String content, String eventId, UUID notificationId) {
+        log.info("📡 SSE 전송 대상 receiverId = {}, eventId = {}", receiverId, eventId);
         NotificationResponseDto response = NotificationResponseDto.builder()
                 .notificationId(notificationId)
                 .notificationType(type)

--- a/notification/src/main/java/com/team15gijo/notification/application/service/v1/NotificationService.java
+++ b/notification/src/main/java/com/team15gijo/notification/application/service/v1/NotificationService.java
@@ -1,10 +1,31 @@
 package com.team15gijo.notification.application.service.v1;
 
+import com.team15gijo.notification.application.dto.v1.NotificationResponseDto;
+import com.team15gijo.notification.domain.model.Notification;
+import com.team15gijo.notification.domain.repository.NotificationRepository;
+import java.util.List;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class NotificationService {
+
+    private final NotificationRepository notificationRepository;
+
+    public List<NotificationResponseDto> getUnreadNotifications(Long userId) {
+        return notificationRepository.findByReceiverAndIsCheckedFalse(userId).stream()
+                .map(NotificationResponseDto::fromEntity)
+                .toList();
+    }
+
+    @Transactional
+    public void updateIsChecked(UUID notificationId, Long userId) {
+        Notification notification = notificationRepository.findByNotificationIdAndReceiver(notificationId, userId)
+                .orElseThrow(() -> new RuntimeException("알림이 존재하지 않습니다."));
+        notification.updateIsChecked();
+    }
 
 }

--- a/notification/src/main/java/com/team15gijo/notification/domain/model/Notification.java
+++ b/notification/src/main/java/com/team15gijo/notification/domain/model/Notification.java
@@ -29,7 +29,7 @@ import org.hibernate.annotations.SQLRestriction;
 public class Notification extends BaseEntity {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @GeneratedValue
     @Column(name = "notification_id")
     private UUID notificationId;
 

--- a/notification/src/main/java/com/team15gijo/notification/domain/model/Notification.java
+++ b/notification/src/main/java/com/team15gijo/notification/domain/model/Notification.java
@@ -25,7 +25,7 @@ import org.hibernate.annotations.SQLRestriction;
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder(access = AccessLevel.PRIVATE)
 @SQLRestriction("deleted_at IS NULL")
-@SQLDelete(sql = "UPDATE p_notification SET is_deleted = true WHERE notification_id = ?")
+@SQLDelete(sql = "UPDATE p_notification SET deleted_at = now(), deleted_by = updated_by WHERE notification_id = ?")
 public class Notification extends BaseEntity {
 
     @Id
@@ -49,5 +49,18 @@ public class Notification extends BaseEntity {
     @Column(name = "event_id")
     private String eventId;     // SSE 이벤트 고유 식별자. 클라이언트 reconnect 및 이벤트 트래킹/재전송용
 
+    public static Notification createNotification(Long receiverId, NotificationType type, String content, String eventId) {
+        return Notification.builder()
+                .notificationType(type)
+                .notificationContent(content)
+                .receiver(receiverId)
+                .isChecked(false)
+                .eventId(eventId)
+                .build();
+    }
+
+    public void updateIsChecked() {
+        this.isChecked = true;
+    }
 
 }

--- a/notification/src/main/java/com/team15gijo/notification/domain/repository/EmitterRepository.java
+++ b/notification/src/main/java/com/team15gijo/notification/domain/repository/EmitterRepository.java
@@ -1,5 +1,29 @@
 package com.team15gijo.notification.domain.repository;
 
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Repository;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@Repository
 public class EmitterRepository {
+
+    private final Map<String, SseEmitter> emitterMap = new ConcurrentHashMap<>();
+
+    public void save(String emitterId, SseEmitter emitter) {
+        emitterMap.put(emitterId, emitter);
+    }
+
+    public Map<String, SseEmitter> findAllByUserId(Long userId) {
+        String key = userId.toString();
+        return emitterMap.entrySet().stream()
+                .filter(e -> e.getKey().startsWith(key))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    public void deleteById(String emitterId) {
+        emitterMap.remove(emitterId);
+    }
 
 }

--- a/notification/src/main/java/com/team15gijo/notification/domain/repository/NotificationRepository.java
+++ b/notification/src/main/java/com/team15gijo/notification/domain/repository/NotificationRepository.java
@@ -1,9 +1,12 @@
 package com.team15gijo.notification.domain.repository;
 
 import com.team15gijo.notification.domain.model.Notification;
+import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface NotificationRepository extends JpaRepository<Notification, UUID> {
-
+    List<Notification> findByReceiverAndIsCheckedFalse(Long receiverId);
+    Optional<Notification> findByNotificationIdAndReceiver(UUID notificationId, Long receiverId);
 }

--- a/notification/src/main/java/com/team15gijo/notification/presentation/controller/v1/EmitterController.java
+++ b/notification/src/main/java/com/team15gijo/notification/presentation/controller/v1/EmitterController.java
@@ -5,11 +5,13 @@ import com.team15gijo.notification.application.service.v1.EmitterService;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
+@CrossOrigin(origins = "*")
 @RestController
 @RequestMapping("/api/v1/sse")
 @RequiredArgsConstructor
@@ -24,6 +26,7 @@ public class EmitterController {
     public SseEmitter subscribe(HttpServletRequest request) {
 //        Long userId = extractUserIdFromRequest(request);
         Long userId = 1L;
+        System.out.println("🔥 SSE 연결 요청 받음! userId = " + userId);
         return emitterService.subscribe(userId);
     }
 

--- a/notification/src/main/java/com/team15gijo/notification/presentation/controller/v1/EmitterController.java
+++ b/notification/src/main/java/com/team15gijo/notification/presentation/controller/v1/EmitterController.java
@@ -1,31 +1,35 @@
 package com.team15gijo.notification.presentation.controller.v1;
 
 
+import com.team15gijo.notification.application.service.v1.EmitterService;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 @RestController
 @RequestMapping("/api/v1/sse")
 @RequiredArgsConstructor
 public class EmitterController {
 
-    /**
-     *   알림 목록 조회
-     */
-
+    private final EmitterService emitterService;
 
     /**
-     *   알림 읽음 처리
+     *  Server-Sent Events(SSE) 연결
      */
+    @GetMapping(value = "/subscribe", produces = "text/event-stream")
+    public SseEmitter subscribe(HttpServletRequest request) {
+//        Long userId = extractUserIdFromRequest(request);
+        Long userId = 1L;
+        return emitterService.subscribe(userId);
+    }
 
-
-
-    /**
-     *   읽지 않은 알림 수
-     *   필요한건가?
-     */
-
-
+//    private Long extractUserIdFromRequest(HttpServletRequest request) {
+//        String token = request.getHeader("Authorization");
+//        return JwtUtils.extractUserId(token);
+//    }
 
 }

--- a/notification/src/main/java/com/team15gijo/notification/presentation/controller/v1/KafkaTestController.java
+++ b/notification/src/main/java/com/team15gijo/notification/presentation/controller/v1/KafkaTestController.java
@@ -1,7 +1,7 @@
 package com.team15gijo.notification.presentation.controller.v1;
 
 
-import com.team15gijo.notification.application.dto.v1.CommentNotificationEvent;
+import com.team15gijo.notification.application.dto.v1.message.CommentNotificationEventDto;
 import com.team15gijo.notification.application.message.KafkaTestProducer;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -17,7 +17,7 @@ public class KafkaTestController {
 
     @GetMapping
     public void sendKafkaMessage() {
-        producer.sendCommentCreate(new CommentNotificationEvent(1L, "정영", "잘 읽었습니다!"));
+        producer.sendCommentCreate(new CommentNotificationEventDto(1L, "정영", "잘 읽었습니다!"));
     }
 
 }

--- a/notification/src/main/java/com/team15gijo/notification/presentation/controller/v1/KafkaTestController.java
+++ b/notification/src/main/java/com/team15gijo/notification/presentation/controller/v1/KafkaTestController.java
@@ -1,0 +1,23 @@
+package com.team15gijo.notification.presentation.controller.v1;
+
+
+import com.team15gijo.notification.application.dto.v1.CommentNotificationEvent;
+import com.team15gijo.notification.application.message.KafkaTestProducer;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/kafka/test")
+@RequiredArgsConstructor
+public class KafkaTestController {
+
+    private final KafkaTestProducer producer;
+
+    @GetMapping
+    public void sendKafkaMessage() {
+        producer.sendCommentCreate(new CommentNotificationEvent(1L, "정영", "잘 읽었습니다!"));
+    }
+
+}

--- a/notification/src/main/java/com/team15gijo/notification/presentation/controller/v1/KafkaTestController.java
+++ b/notification/src/main/java/com/team15gijo/notification/presentation/controller/v1/KafkaTestController.java
@@ -1,7 +1,9 @@
 package com.team15gijo.notification.presentation.controller.v1;
 
 
+import com.team15gijo.notification.application.dto.v1.message.ChatNotificationEventDto;
 import com.team15gijo.notification.application.dto.v1.message.CommentNotificationEventDto;
+import com.team15gijo.notification.application.dto.v1.message.FollowNotificationEventDto;
 import com.team15gijo.notification.application.message.KafkaTestProducer;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -15,9 +17,19 @@ public class KafkaTestController {
 
     private final KafkaTestProducer producer;
 
-    @GetMapping
-    public void sendKafkaMessage() {
+    @GetMapping("/comment")
+    public void sendCommentKafkaMessage() {
         producer.sendCommentCreate(new CommentNotificationEventDto(1L, "정영", "잘 읽었습니다!"));
+    }
+
+    @GetMapping("/follow")
+    public void sendFollowKafkaMessage() {
+        producer.sendFollowCreate(new FollowNotificationEventDto(1L, "정영"));
+    }
+
+    @GetMapping("/chat")
+    public void sendChatKafkaMessage() {
+        producer.sendChatCreate(new ChatNotificationEventDto(1L, "정영"));
     }
 
 }

--- a/notification/src/main/java/com/team15gijo/notification/presentation/controller/v1/NotificationController.java
+++ b/notification/src/main/java/com/team15gijo/notification/presentation/controller/v1/NotificationController.java
@@ -1,6 +1,16 @@
 package com.team15gijo.notification.presentation.controller.v1;
 
+import com.team15gijo.notification.application.dto.v1.NotificationResponseDto;
+import com.team15gijo.notification.application.service.v1.NotificationService;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.List;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -8,7 +18,39 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1/notifications")
 @RequiredArgsConstructor
 public class NotificationController {
+
+    private final NotificationService notificationService;
     /**
-     *  Server-Sent Events(SSE) 연결
+     *  미확인 알림 목록 조회
+     */
+    @GetMapping
+    public ResponseEntity<List<NotificationResponseDto>> getUnreadNotifications(
+            HttpServletRequest request) {
+//        Long userId = extractUserIdFromRequest(request);
+        Long userId = 1L;
+        return ResponseEntity.ok(notificationService.getUnreadNotifications(userId));
+    }
+
+
+
+    /**
+     *   알림 읽음 처리
+     */
+    @PatchMapping ("/{notificationId}/read")
+    public void markAsRead(@PathVariable UUID notificationId, HttpServletRequest request) {
+//        Long userId = extractUserIdFromRequest(request);
+        Long userId = 1L;
+        notificationService.updateIsChecked(notificationId, userId);
+    }
+
+//    private Long extractUserIdFromRequest(HttpServletRequest request) {
+//        String token = request.getHeader("Authorization");
+//        return JwtUtils.extractUserId(token); // 구현 필요
+//    }
+
+
+    /**
+     *   읽지 않은 알림 수
+     *   필요한건가?
      */
 }

--- a/notification/src/main/resources/application.yml
+++ b/notification/src/main/resources/application.yml
@@ -17,9 +17,13 @@ spring:
         use_sql_comments: true
   kafka:
     bootstrap-servers: localhost:9092
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
     consumer:
       key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
-      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
+      auto-offset-reset: earliest
 
 
 server:

--- a/notification/src/main/resources/templates/test.html
+++ b/notification/src/main/resources/templates/test.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8">
+  <title>SSE 테스트</title>
+</head>
+<body>
+<h1>SSE 알림 수신 테스트</h1>
+<ul id="log"></ul>
+
+<script>
+  const eventSource = new EventSource("http://localhost:19098/api/v1/sse/subscribe");
+
+  eventSource.onopen = () => {
+    console.log("SSE 연결 완료");
+  };
+
+  eventSource.onmessage = function (event) {
+    const data = JSON.parse(event.data);
+    const li = document.createElement("li");
+    li.textContent = `[기본] ${data.notificationContent}`;
+    document.getElementById("log").appendChild(li);
+  };
+
+  eventSource.addEventListener("CONNECT", function (event) {
+    const li = document.createElement("li");
+    li.textContent = `[CONNECT] 연결됨`;
+    document.getElementById("log").appendChild(li);
+  });
+
+  eventSource.addEventListener("NEW", function (event) {
+    const data = JSON.parse(event.data);
+    const li = document.createElement("li");
+    li.textContent = `[NEW] ${data.notificationContent}`;
+    document.getElementById("log").appendChild(li);
+  });
+
+  eventSource.onerror = function (event) {
+    console.error("SSE 연결 오류 발생", event);
+  };
+</script>
+</body>
+</html>


### PR DESCRIPTION
# 💡 PR Summary - notification mvp 기능 구현

<!-- 어떤 작업에 대한 PR 인지 위 주석을 대신하여 적어주세요 -->

### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [x] 신규 기능 추가/수정
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

</br>

### 📝 Description
댓글/팔로우/채팅 이벤트 발생 시 알림을 보내는 기능 mvp 완성
---

<!-- 어떤 작업을 했는지 간단하게 적어주세요 -->
- **as-is**
    - 

- **to-be**
    - kafka 메세지 수신 시, SSE를 통한 알림 기능 구현

</br>
테스트 방법
1. 유레카 서버, 알림 서버 실행 

2. 알림 서버쪽 resource/templates의 test.html 브라우저에 열기 

3. 알림 서버에서 SSE 연결확인 

4. 브라우저에서도 '연결됨' 확인 

5. postman으로 http://localhost:19098/api/kafka/test/comment GET요청 보내서 브라우저에 알림 뜨는 것 확인 

6. 엔트포인트 마지막 comment부분 follow와 chat으로 바꿔보면서 알림 확인


### 📚 Etc

---

<!-- 작업 중 특이사항이 생기면 적어주세요 -->
- 어제 이야기 나왔었던 공통 모듈의 handleAsyncTimeoutException 부분 주석처리 되었습니다.

</br>
</br>
