### PR TITLE
Feature/v1/12 chat crud 채팅방 CRUD 2

### DIFF
--- a/chat/src/main/java/com/team15gijo/chat/ChatApplication.java
+++ b/chat/src/main/java/com/team15gijo/chat/ChatApplication.java
@@ -2,8 +2,10 @@ package com.team15gijo.chat;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableFeignClients
 @EnableJpaAuditing
 @SpringBootApplication(scanBasePackages = {"com.team15gijo.chat"
 //	, "com.team15gijo.common"

--- a/chat/src/main/java/com/team15gijo/chat/application/dto/v1/ChatRoomResponseDto.java
+++ b/chat/src/main/java/com/team15gijo/chat/application/dto/v1/ChatRoomResponseDto.java
@@ -1,6 +1,8 @@
 package com.team15gijo.chat.application.dto.v1;
 
+import com.team15gijo.chat.domain.model.ChatRoomParticipant;
 import com.team15gijo.chat.domain.model.ChatRoomType;
+import java.util.Set;
 import java.util.UUID;
 import lombok.Builder;
 import lombok.Getter;
@@ -10,4 +12,5 @@ import lombok.Getter;
 public class ChatRoomResponseDto {
     private UUID chatRoomId;
     private ChatRoomType chatRoomType;
+    private Set<ChatRoomParticipant> chatRoomParticipants;
 }

--- a/chat/src/main/java/com/team15gijo/chat/application/service/impl/v1/ChatMessageService.java
+++ b/chat/src/main/java/com/team15gijo/chat/application/service/impl/v1/ChatMessageService.java
@@ -8,6 +8,7 @@ import com.team15gijo.chat.domain.model.ChatRoomParticipant;
 import com.team15gijo.chat.domain.repository.ChatMessageRepository;
 import com.team15gijo.chat.domain.repository.ChatRoomParticipantRepository;
 import com.team15gijo.chat.domain.repository.ChatRoomRepository;
+import com.team15gijo.chat.infrastructure.client.v1.FeignClientService;
 import com.team15gijo.chat.presentation.dto.v1.ChatMessageRequestDto;
 import com.team15gijo.chat.presentation.dto.v1.ChatMessageResponseDto;
 import com.team15gijo.chat.presentation.dto.v1.ChatRoomParticipantRequestDto;
@@ -35,6 +36,8 @@ public class ChatMessageService {
     private final ChatRoomRepository chatRoomRepository;
     private final ChatRoomParticipantRepository chatRoomParticipantRepository;
 
+    private final FeignClientService feignClientService;
+
     /**
      * 채팅방 생성(chatRoomType, receiver)에 따른 채팅방 참여자 생성
      * @param requestDto
@@ -43,9 +46,13 @@ public class ChatMessageService {
      * TODO: userId, nickname 추후 구현
      */
     public ChatRoomResponseDto createChatRoom(ChatRoomRequestDto requestDto) {
-        // TODO: User feign client 유효성 검사
-        // 현재 상대방 닉네임을 받아 오기 때문에 사용자 feign client로 존재하는지 확인 필요
+        // TODO: User feign client 유효성 검사 구현 후, 연결 확인
+        // 채팅방 생성 시, 상대방 계정 조회하는지 nickname 으로 판단
         String receiverNickname = requestDto.getReceiverNickname();
+//        Boolean nicknameExists = feignClientService.fetchNicknameExists(receiverNickname);
+//        if(!nicknameExists) {
+//            throw new NullPointerException("Nickname " + receiverNickname + " does not exist");
+//        }
 
         // 채팅방 참여자 생성 및 저장
         ChatRoomParticipant addParticipants = ChatRoomParticipant.builder()

--- a/chat/src/main/java/com/team15gijo/chat/domain/model/ChatMessageDocument.java
+++ b/chat/src/main/java/com/team15gijo/chat/domain/model/ChatMessageDocument.java
@@ -13,7 +13,8 @@ public class ChatMessageDocument {
     @Id
     private String _id;
     private UUID chatRoomId;
-    private String senderId;
+    private Long senderId;
+    private String senderNickname;
     private ConnectionType connectionType;
     private String messageContent;
     private ChatMessageType chatMessageType;
@@ -22,7 +23,9 @@ public class ChatMessageDocument {
 
     public ChatMessageResponseDto toResponse() {
         return ChatMessageResponseDto.builder()
+            .id(_id)
             .senderId(senderId)
+            .senderNickname(senderNickname)
             .message(messageContent)
             .sentAt(sentAt)
             .readStatus(readStatus).build();

--- a/chat/src/main/java/com/team15gijo/chat/domain/model/ChatRoom.java
+++ b/chat/src/main/java/com/team15gijo/chat/domain/model/ChatRoom.java
@@ -2,13 +2,18 @@ package com.team15gijo.chat.domain.model;
 
 import com.team15gijo.chat.application.dto.v1.ChatRoomResponseDto;
 import com.team15gijo.common.base.BaseEntity;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import java.util.Set;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -34,10 +39,15 @@ public class ChatRoom extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private ChatRoomType chatRoomType;
 
+    @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @JoinColumn(name = "chat_room_id") // ChatRoomParticipants 테이블의 chat_room_id 외래키
+    private Set<ChatRoomParticipant> chatRoomParticipants;
+
     public ChatRoomResponseDto toResponse() {
         return ChatRoomResponseDto.builder()
             .chatRoomId(chatRoomId)
             .chatRoomType(chatRoomType)
+            .chatRoomParticipants(chatRoomParticipants)
             .build();
     }
 }

--- a/chat/src/main/java/com/team15gijo/chat/domain/model/ChatRoomParticipant.java
+++ b/chat/src/main/java/com/team15gijo/chat/domain/model/ChatRoomParticipant.java
@@ -32,17 +32,13 @@ public class ChatRoomParticipant extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.UUID)
     private UUID id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "chat_room_id")
-    private ChatRoom chatRoom;
-
     private Long userId;
 
     private Boolean activation; // 활성화 상태(True: 참여, False: 퇴장)
 
     public ChatRoomParticipantResponseDto toResponse() {
         return ChatRoomParticipantResponseDto.builder()
-            .chatRoomId(chatRoom.getChatRoomId())
+            .id(id)
             .userId(userId)
             .activation(activation)
             .build();

--- a/chat/src/main/java/com/team15gijo/chat/domain/repository/ChatRoomParticipantRepository.java
+++ b/chat/src/main/java/com/team15gijo/chat/domain/repository/ChatRoomParticipantRepository.java
@@ -1,22 +1,7 @@
 package com.team15gijo.chat.domain.repository;
 
-import com.team15gijo.chat.domain.model.ChatRoom;
 import com.team15gijo.chat.domain.model.ChatRoomParticipant;
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ChatRoomParticipantRepository extends JpaRepository<ChatRoomParticipant, Long> {
-
-    List<ChatRoomParticipant> findByUserId(Long userId);
-
-    Optional<ChatRoomParticipant> findByUserIdAndChatRoom_ChatRoomId(Long userId, UUID chatRoomId);
-
-    default List<ChatRoom> findChatRoomsByUserId(Long userId) {
-        List<ChatRoomParticipant> participants = findByUserId(userId);
-        return participants.stream()
-            .map(ChatRoomParticipant::getChatRoom)
-            .toList();
-    }
 }

--- a/chat/src/main/java/com/team15gijo/chat/infrastructure/client/v1/FeignClientService.java
+++ b/chat/src/main/java/com/team15gijo/chat/infrastructure/client/v1/FeignClientService.java
@@ -1,0 +1,19 @@
+package com.team15gijo.chat.infrastructure.client.v1;
+
+import com.team15gijo.chat.infrastructure.client.v1.user.UserClient;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class FeignClientService {
+
+    private final UserClient userClient;
+
+    /**
+     * User 서비스에서 nickname 존재여부 확인 - Feign Client
+     */
+    public Boolean fetchNicknameExists(String receiverNickname) {
+        return userClient.nicknameExists(receiverNickname);
+    }
+}

--- a/chat/src/main/java/com/team15gijo/chat/infrastructure/client/v1/FeignClientService.java
+++ b/chat/src/main/java/com/team15gijo/chat/infrastructure/client/v1/FeignClientService.java
@@ -1,6 +1,7 @@
 package com.team15gijo.chat.infrastructure.client.v1;
 
 import com.team15gijo.chat.infrastructure.client.v1.user.UserClient;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -13,7 +14,7 @@ public class FeignClientService {
     /**
      * User 서비스에서 nickname 존재여부 확인 - Feign Client
      */
-    public Boolean fetchNicknameExists(String receiverNickname) {
-        return userClient.nicknameExists(receiverNickname);
+    public Long fetchUserIdByNickname(String receiverNickname) {
+        return userClient.getUserIdByNickname(receiverNickname);
     }
 }

--- a/chat/src/main/java/com/team15gijo/chat/infrastructure/client/v1/user/UserClient.java
+++ b/chat/src/main/java/com/team15gijo/chat/infrastructure/client/v1/user/UserClient.java
@@ -1,0 +1,16 @@
+package com.team15gijo.chat.infrastructure.client.v1.user;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@FeignClient(name = "user-service", url = "http://localhost:19092/api/v1/users")
+public interface UserClient {
+
+    /**
+     * User 서비스에서 nickname 존재여부 확인 - Feign Client
+     * 채팅방 생성 시, 상대방 계정 조회하는지 nickname 으로 판단
+     */
+    @GetMapping("/{nickname}")
+    Boolean nicknameExists(@PathVariable("nickname") String nickname);
+}

--- a/chat/src/main/java/com/team15gijo/chat/infrastructure/client/v1/user/UserClient.java
+++ b/chat/src/main/java/com/team15gijo/chat/infrastructure/client/v1/user/UserClient.java
@@ -1,5 +1,6 @@
 package com.team15gijo.chat.infrastructure.client.v1.user;
 
+import java.util.UUID;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -12,5 +13,5 @@ public interface UserClient {
      * 채팅방 생성 시, 상대방 계정 조회하는지 nickname 으로 판단
      */
     @GetMapping("/{nickname}")
-    Boolean nicknameExists(@PathVariable("nickname") String nickname);
+    Long getUserIdByNickname(@PathVariable("nickname") String nickname);
 }

--- a/chat/src/main/java/com/team15gijo/chat/presentation/dto/v1/ChatMessageRequestDto.java
+++ b/chat/src/main/java/com/team15gijo/chat/presentation/dto/v1/ChatMessageRequestDto.java
@@ -1,8 +1,5 @@
 package com.team15gijo.chat.presentation.dto.v1;
 
-import com.team15gijo.chat.domain.model.ChatMessageType;
-import com.team15gijo.chat.domain.model.ConnectionType;
-import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.Builder;
 import lombok.Getter;
@@ -12,12 +9,7 @@ import lombok.ToString;
 @Builder
 @ToString
 public class ChatMessageRequestDto {
-    private String _id;
     private UUID chatRoomId;
-    private String senderId;
-    private ConnectionType connectionType;
+    private Long senderId;
     private String message;
-    private ChatMessageType chatMessageType;
-    private LocalDateTime sentAt;
-    private Boolean readStatus;
 }

--- a/chat/src/main/java/com/team15gijo/chat/presentation/dto/v1/ChatMessageResponseDto.java
+++ b/chat/src/main/java/com/team15gijo/chat/presentation/dto/v1/ChatMessageResponseDto.java
@@ -11,7 +11,9 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 public class ChatMessageResponseDto {
-    private String senderId;
+    private String id;
+    private Long senderId;
+    private String senderNickname;
     private String message;
     private LocalDateTime sentAt;
     private Boolean readStatus;

--- a/chat/src/main/java/com/team15gijo/chat/presentation/dto/v1/ChatRoomParticipantResponseDto.java
+++ b/chat/src/main/java/com/team15gijo/chat/presentation/dto/v1/ChatRoomParticipantResponseDto.java
@@ -11,7 +11,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 public class ChatRoomParticipantResponseDto {
-    private UUID chatRoomId;
+    private UUID id;
     private Long userId;
     private Boolean activation;
 }

--- a/chat/src/main/resources/templates/index.html
+++ b/chat/src/main/resources/templates/index.html
@@ -10,13 +10,51 @@
 
     function connect() {
       chatRoomId = document.getElementById('chatRoomId').value;
-      const socket = new SockJS('/ws-stomp');
-      stompClient = Stomp.over(socket);
-      stompClient.connect({}, function (frame) {
-        console.log('Connected: ' + frame);
-        stompClient.subscribe('/topic/chat/' + chatRoomId, function (message) {
-          showMessage(JSON.parse(message.body));
+      senderId = parseInt(document.getElementById('senderId').value);
+
+      // 채팅방 ID 유효성 검증 API 호출
+      fetch(`/api/v1/chats/validate/${chatRoomId}`)
+        .then(response => response.json())
+        .then(data => {
+          if(!data.data.valid) {
+            // 채팅방 id가 유효하지 않을 때 오류 표시
+            alert('존재하지 않은 채팅방 ID 입니다. 다시 확인해주세요.');
+          } else {
+            console.log("채팅방 ID 유효성 검증 성공");
+          }
+        })
+        .catch(error => {
+          console.error("API 호출 실패: " + error);
+          alert('채팅방 ID 유효성 검증 실패. 서버 오류를 확인해주세요.');
         });
+
+      // 채팅방에 해당하는 userId 유효성 검증 API 호출
+      fetch(`/api/v1/chats/validate/${chatRoomId}/${senderId}`)
+        .then(response => response.json())
+        .then(data => {
+          if(!data.data.valid) {
+            // 해당 chatRoomId의 userId가 유효하지 않을 때 오류 표시
+            alert('해당 채팅방의 사용자가 아닙니다. 다시 확인해주세요.');
+          } else {
+            console.log("채팅방 ID에 해당하는 senderId 유효성 검증 성공");
+
+            // 채팅방 id과 userId가 유효성 검증 성공하면 webSocket 연결
+            const socket = new SockJS('/ws-stomp');
+            stompClient = Stomp.over(socket);
+            stompClient.connect({}, function (frame) {
+              console.log('소켓 Connected: ' + frame);
+              stompClient.subscribe('/topic/chat/' + chatRoomId, function (message) {
+                showMessage(JSON.parse(message.body));
+              });
+            }, function (error) {
+              console.error("소켓 Connection error: ", error);
+              alert('채팅방 연결 종료 및 실패하였습니다. 서버 오류를 확인해주세요.');
+            });
+          }
+        })
+      .catch(error => {
+        console.error("API 호출 실패: " + error);
+        alert('채팅방의 사용자 ID 유효성 검증 실패. 서버 오류를 확인해주세요.');
       });
     }
 
@@ -24,24 +62,28 @@
       if (stompClient !== null) {
         stompClient.disconnect();
       }
-      console.log("Disconnected");
+      console.log("소켓 Disconnected");
+      alert('채팅방 연결 종료하였습니다. 다시 연결해주세요!');
     }
 
     function sendMessage() {
-      const senderId = document.getElementById('senderId').value;
+      const senderId = parseInt(document.getElementById('senderId').value); // 문자열을 숫자로 변환
       const message = document.getElementById('message').value;
       stompClient.send("/app/chat/" + chatRoomId, {}, JSON.stringify({
         'chatRoomId': chatRoomId,
         'senderId': senderId,
         'message': message
-      }));
+      }), {}, function (error) {
+        console.error("메시지 전송 실패: " + error);
+        if (error && error.header && error.header.error) { // 헤더 존재 여부 확인
+          alert("메시지 전송 실패: " + error.header.error);
+        } else {
+          alert("메시지 전송 실패. 서버 오류를 확인해주세요.");
+        }
+      });
     }
 
     function showMessage(message) {
-      console.log("showMessage 함수 내 message=" + message);
-      for (const key in message) {
-        console.log(key + ": " + message[key]);
-      }
       const messages = document.getElementById('messages');
       const p = document.createElement('p');
       p.textContent = message.senderId + ': ' + message.message
@@ -56,7 +98,7 @@
   <input type="text" id="chatRoomId" value="1f46fcd1-e676-402e-8703-2183be76b021" />
 </div>
 <div>
-  <label>Sender:</label>
+  <label>SenderId:</label>
   <input type="text" id="senderId" value="1L" />
 </div>
 <div>


### PR DESCRIPTION
# 💡 PR Summary - 채팅방 인원 제한 및 nickname 유효성 검증

<!-- 어떤 작업에 대한 PR 인지 위 주석을 대신하여 적어주세요 -->

### PR 타입

- [X] 신규 기능 추가/수정
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

</br>

### 📝 Description

---

<!-- 어떤 작업을 했는지 간단하게 적어주세요 -->
- **as-is**
    - 채팅방의 기본적인 crud 기능 구현

- **to-be**
    - 1:1 채팅방 생성 시, 사용자(nickname)으로 user feign client 유효성 검사 추가(주석 처리) -> API 구현 후 테스트 필요
    - 채팅방 생성 시, 2명의 사용자 채팅방 참여자로 등록하여 chatRoomId에 해당하는 참여자(senderId)로 웹소켓 접속 제한

</br>

### 📚 Etc

---

<!-- 작업 중 특이사항이 생기면 적어주세요 -->
- 동일한 userId가 채팅방 중복 연결 처리(진행중)
- 재접속 시, 이전 메시지 내역 불러오기(예정)

<br>

### 관련 이슈

---

#51 

</br>
</br>