### PR TITLE
Feature/v2/121 chat kafka : 날짜별/텍스트별 메시지 검색

### DIFF
--- a/chat/build.gradle
+++ b/chat/build.gradle
@@ -64,6 +64,10 @@ tasks.withType(JavaCompile).configureEach {
 	options.annotationProcessorGeneratedSourcesDirectory = file("build/generated")
 }
 
+clean {
+	delete file("build/generated")
+}
+
 dependencyManagement {
 	imports {
 		mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"

--- a/chat/build.gradle
+++ b/chat/build.gradle
@@ -27,7 +27,7 @@ dependencies {
 	implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.0'
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
+
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-websocket'
 	// SocketJs & STOMP JS
@@ -40,9 +40,28 @@ dependencies {
 	implementation 'org.springframework.kafka:spring-kafka'
 	runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
 	runtimeOnly 'org.postgresql:postgresql'
+	// ✅ MongoDB + QueryDSL Core
+	implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
+	implementation 'com.querydsl:querydsl-core:5.0.0'
+	// ✅ APT (Annotation Processor)
+	annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:general'
+	annotationProcessor 'org.springframework.data:spring-data-mongodb'
+
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.kafka:spring-kafka-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+}
+
+sourceSets {
+	main {
+		java {
+			srcDirs = ["src/main/java", "build/generated"]
+		}
+	}
+}
+
+tasks.withType(JavaCompile).configureEach {
+	options.annotationProcessorGeneratedSourcesDirectory = file("build/generated")
 }
 
 dependencyManagement {

--- a/chat/src/main/java/com/team15gijo/chat/application/service/ChatServiceV2.java
+++ b/chat/src/main/java/com/team15gijo/chat/application/service/ChatServiceV2.java
@@ -6,6 +6,7 @@ import com.team15gijo.chat.domain.model.v2.ChatMessageDocumentV2;
 import com.team15gijo.chat.domain.model.v2.ChatRoomV2;
 import com.team15gijo.chat.presentation.dto.v2.ChatMessageRequestDtoV2;
 import com.team15gijo.chat.presentation.dto.v2.ChatRoomRequestDtoV2;
+import java.time.LocalDateTime;
 import java.util.Map;
 import java.util.UUID;
 import org.springframework.data.domain.Page;
@@ -50,4 +51,7 @@ public interface ChatServiceV2 {
 
     void sendMessage(
         ChatMessageRequestDtoV2 requestDto, SimpMessageHeaderAccessor headerAccessor);
+
+    Page<ChatMessageDocumentV2> searchMessages(
+        UUID chatRoomId, LocalDateTime sentAt, String messageContent, Long userId, Pageable pageable);
 }

--- a/chat/src/main/java/com/team15gijo/chat/application/service/impl/v2/ChatServiceImplV2.java
+++ b/chat/src/main/java/com/team15gijo/chat/application/service/impl/v2/ChatServiceImplV2.java
@@ -24,6 +24,7 @@ import com.team15gijo.chat.infrastructure.kafka.util.KafkaUtil;
 import com.team15gijo.chat.presentation.dto.v2.ChatMessageRequestDtoV2;
 import com.team15gijo.chat.presentation.dto.v2.ChatRoomRequestDtoV2;
 import com.team15gijo.common.exception.CustomException;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -449,6 +450,16 @@ public class ChatServiceImplV2 implements ChatServiceV2 {
         // 카프카 채팅 메시지 처리
         kafkaUtil.sendKafkaEvent(CHAT_MESSAGE_EVENT_TOPIC, chatMessage);
         log.info("[ChatServiceImplV2] sendMessage 메소드 종료 - Kafka 발행 완료");
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Page<ChatMessageDocumentV2> searchMessages(UUID chatRoomId, LocalDateTime sentAt, String messageContent, Long userId, Pageable pageable) {
+        log.info("[ChatServiceImplV2] searchMessages 메소드 시작");
+        // 채팅방 id 및 userId 유효성 검증
+        checkRoomIdAndUserId(chatRoomId, userId);
+
+        return chatMessageRepository.searchMessages(chatRoomId, sentAt, messageContent, pageable);
     }
 
     // 채팅방 id 및 userId 유효성 검증

--- a/chat/src/main/java/com/team15gijo/chat/domain/exception/ChatDomainExceptionCode.java
+++ b/chat/src/main/java/com/team15gijo/chat/domain/exception/ChatDomainExceptionCode.java
@@ -13,7 +13,8 @@ public enum ChatDomainExceptionCode implements ExceptionCode {
     CHAT_ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "채팅방이 존재하지 않습니다."),
     CHAT_ROOM_USER_ID_NOT_FOUND(HttpStatus.NOT_FOUND, "채팅방 유저 아이디를 찾을 수 없습니다."),
     MESSAGE_NOT_FOUND_FOR_CHAT_ROOM(HttpStatus.NOT_FOUND, "채팅방에 해당하는 메시지 내역이 찾을 수 없습니다."),
-    MESSAGE_ID_NOT_FOUND(HttpStatus.NOT_FOUND,"채팅 메시지가 존재하지 않습니다.");
+    MESSAGE_ID_NOT_FOUND(HttpStatus.NOT_FOUND, "채팅 메시지가 존재하지 않습니다."),
+    SENT_AT_DATETIME_PARSE(HttpStatus.BAD_REQUEST, "sentAt 형식이 유효하지 않습니다. 'yyyy-MM-dd' 형식이어야 합니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/chat/src/main/java/com/team15gijo/chat/domain/model/v2/ChatMessageDocumentV2.java
+++ b/chat/src/main/java/com/team15gijo/chat/domain/model/v2/ChatMessageDocumentV2.java
@@ -1,5 +1,6 @@
 package com.team15gijo.chat.domain.model.v2;
 
+import com.querydsl.core.annotations.QueryEntity;
 import com.team15gijo.chat.application.dto.v2.ChatMessageResponseDtoV2;
 import com.team15gijo.chat.presentation.dto.v2.ChatMessageRequestDtoV2;
 import jakarta.persistence.Column;
@@ -12,6 +13,7 @@ import org.springframework.data.annotation.CreatedBy;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.mongodb.core.mapping.Document;
 
+@QueryEntity
 @Getter
 @Builder
 @Document(collection = "chat")

--- a/chat/src/main/java/com/team15gijo/chat/domain/repository/v2/ChatMessageCustomRepositoryV2.java
+++ b/chat/src/main/java/com/team15gijo/chat/domain/repository/v2/ChatMessageCustomRepositoryV2.java
@@ -1,0 +1,13 @@
+package com.team15gijo.chat.domain.repository.v2;
+
+import com.team15gijo.chat.domain.model.v2.ChatMessageDocumentV2;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface ChatMessageCustomRepositoryV2 {
+
+    Page<ChatMessageDocumentV2> searchMessages(
+        UUID chatRoomId, LocalDateTime sentAt, String messageContent, Pageable pageable);
+}

--- a/chat/src/main/java/com/team15gijo/chat/domain/repository/v2/ChatMessageCustomRepositoryV2Impl.java
+++ b/chat/src/main/java/com/team15gijo/chat/domain/repository/v2/ChatMessageCustomRepositoryV2Impl.java
@@ -1,6 +1,6 @@
 package com.team15gijo.chat.domain.repository.v2;
 
-import static com.team15gijo.chat.infrastructure.config.RegexUtils.escapeRegex;
+import static com.team15gijo.chat.infrastructure.utils.RegexUtils.escapeRegex;
 
 import com.team15gijo.chat.domain.model.v2.ChatMessageDocumentV2;
 import com.team15gijo.chat.domain.model.v2.QChatMessageDocumentV2;

--- a/chat/src/main/java/com/team15gijo/chat/domain/repository/v2/ChatMessageCustomRepositoryV2Impl.java
+++ b/chat/src/main/java/com/team15gijo/chat/domain/repository/v2/ChatMessageCustomRepositoryV2Impl.java
@@ -1,0 +1,94 @@
+package com.team15gijo.chat.domain.repository.v2;
+
+import static com.team15gijo.chat.infrastructure.config.RegexUtils.escapeRegex;
+
+import com.team15gijo.chat.domain.model.v2.ChatMessageDocumentV2;
+import com.team15gijo.chat.domain.model.v2.QChatMessageDocumentV2;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+
+@Slf4j
+@RequiredArgsConstructor
+public class ChatMessageCustomRepositoryV2Impl implements ChatMessageCustomRepositoryV2 {
+
+    private final MongoTemplate mongoTemplate;
+
+    @Override
+    public Page<ChatMessageDocumentV2> searchMessages(
+        UUID chatRoomId, LocalDateTime sentAt, String messageContent, Pageable pageable) {
+
+        QChatMessageDocumentV2 message = QChatMessageDocumentV2.chatMessageDocumentV2;
+
+        Criteria baseCriteria = new Criteria()
+            .andOperator(
+                Criteria.where(message.chatRoomId.getMetadata().getName()).is(chatRoomId),
+                Criteria.where(message.deletedAt.getMetadata().getName()).is(null)
+            );
+
+        // or 조건
+        List<Criteria> orConditions = new ArrayList<>();
+
+        // sentAt 기본값이 false 면 모든 날짜로 검색
+        if(sentAt != null) {
+            log.info(">> sentAt={}", sentAt);
+              orConditions.add(
+                // ChatMessage 도큐먼트 필드 내 sentAt 필드 추출(해당 필드의 실제 데이터베이스 이름)
+                Criteria.where(message.sentAt.getMetadata().getName())
+                    .gte(sentAt)
+            );
+        }
+
+        // messageContent 가 기본값이 아니면 검색 조건 추가
+        if (messageContent != null && !messageContent.isEmpty()) {
+            log.info(">> messageContent={}", messageContent);
+            /*
+             * 정규 표현식의 모든 메타 문자를 자동으로 이스케이프 처리
+             * "^" :  URL 인코딩 시 403 Bad Request 발생으로 -> "%5E" 입력하면 "^"로 검색 처리
+             * "+" : URL 인코딩 시 " "(공백 문자) 전달되어 메시지 전체 조회됨 -> "%2B" 입력하면 "+"로 검색 처리
+             */
+            String regexPattern = escapeRegex(messageContent);
+            log.info(">> regexPattern={}", regexPattern);
+
+            orConditions.add(
+                // regex(messageContent) : 검색할 정규 표현식 패턴
+                // "i" 옵션은 정규 표현식 검색 시 대소문자를 구분하지 않도록 지정
+                Criteria.where(message.messageContent.getMetadata().getName()).regex(regexPattern, "i")
+            );
+        }
+        log.info(">> orConditions={}", orConditions);
+
+        // 최종 조건 : baseCriteria AND (sentAt OR messageContent)
+        Criteria finalCriteria;
+
+        if(orConditions.isEmpty()) {
+            finalCriteria = baseCriteria;
+        } else {
+            finalCriteria = new Criteria().andOperator(
+                baseCriteria,
+                // 주어진 orConditions Criteria 객체들을 $or 연산자를 사용해 결합
+                // new Criteria[0] : Criteria 타입의 배열로 변환
+                new Criteria().orOperator(orConditions.toArray(new Criteria[0]))
+            );
+        }
+
+        Query query = new Query(finalCriteria).with(pageable);
+        List<ChatMessageDocumentV2> content = mongoTemplate.find(query, ChatMessageDocumentV2.class);
+        log.info(">> content={}", content);
+
+        Query countQuery = new Query(finalCriteria);
+        long totalCount = mongoTemplate.count(countQuery, ChatMessageDocumentV2.class);
+        log.info(">> totalCount={}", totalCount);
+
+        return new PageImpl<>(content, pageable, totalCount);
+    }
+}

--- a/chat/src/main/java/com/team15gijo/chat/domain/repository/v2/ChatMessageCustomRepositoryV2Impl.java
+++ b/chat/src/main/java/com/team15gijo/chat/domain/repository/v2/ChatMessageCustomRepositoryV2Impl.java
@@ -89,6 +89,11 @@ public class ChatMessageCustomRepositoryV2Impl implements ChatMessageCustomRepos
         long totalCount = mongoTemplate.count(countQuery, ChatMessageDocumentV2.class);
         log.info(">> totalCount={}", totalCount);
 
+        // 메시지 totalCount 가 많을 경우, 에러 로그 추가
+        if (totalCount > 1000) {
+            log.warn(">> chatRoomId={}의 레코드={}이다. 추후 검색 기준 구체화가 필요하다.", chatRoomId, totalCount);
+        }
+
         return new PageImpl<>(content, pageable, totalCount);
     }
 }

--- a/chat/src/main/java/com/team15gijo/chat/domain/repository/v2/ChatMessageRepositoryV2.java
+++ b/chat/src/main/java/com/team15gijo/chat/domain/repository/v2/ChatMessageRepositoryV2.java
@@ -1,8 +1,14 @@
 package com.team15gijo.chat.domain.repository.v2;
 
 import com.team15gijo.chat.domain.model.v2.ChatMessageDocumentV2;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.mongodb.repository.MongoRepository;
 
-public interface ChatMessageRepositoryV2 extends MongoRepository<ChatMessageDocumentV2, String> {
-
+public interface ChatMessageRepositoryV2 extends
+    MongoRepository<ChatMessageDocumentV2, String>,
+    ChatMessageCustomRepositoryV2 {
+    Page<ChatMessageDocumentV2> searchMessages(UUID chatRoomId, LocalDateTime sentAt, String messageContent, Pageable pageable);
 }

--- a/chat/src/main/java/com/team15gijo/chat/domain/repository/v2/ChatMessageRepositoryV2.java
+++ b/chat/src/main/java/com/team15gijo/chat/domain/repository/v2/ChatMessageRepositoryV2.java
@@ -1,14 +1,9 @@
 package com.team15gijo.chat.domain.repository.v2;
 
 import com.team15gijo.chat.domain.model.v2.ChatMessageDocumentV2;
-import java.time.LocalDateTime;
-import java.util.UUID;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.mongodb.repository.MongoRepository;
 
 public interface ChatMessageRepositoryV2 extends
     MongoRepository<ChatMessageDocumentV2, String>,
     ChatMessageCustomRepositoryV2 {
-    Page<ChatMessageDocumentV2> searchMessages(UUID chatRoomId, LocalDateTime sentAt, String messageContent, Pageable pageable);
 }

--- a/chat/src/main/java/com/team15gijo/chat/domain/repository/v2/ChatRoomQueryDslRepositoryV2Custom.java
+++ b/chat/src/main/java/com/team15gijo/chat/domain/repository/v2/ChatRoomQueryDslRepositoryV2Custom.java
@@ -1,5 +1,0 @@
-package com.team15gijo.chat.domain.repository.v2;
-
-public interface ChatRoomQueryDslRepositoryV2Custom {
-
-}

--- a/chat/src/main/java/com/team15gijo/chat/domain/repository/v2/ChatRoomQueryDslRepositoryV2CustomImpl.java
+++ b/chat/src/main/java/com/team15gijo/chat/domain/repository/v2/ChatRoomQueryDslRepositoryV2CustomImpl.java
@@ -1,5 +1,0 @@
-package com.team15gijo.chat.domain.repository.v2;
-
-public class ChatRoomQueryDslRepositoryV2CustomImpl implements ChatRoomQueryDslRepositoryV2Custom {
-
-}

--- a/chat/src/main/java/com/team15gijo/chat/domain/repository/v2/ChatRoomRepositoryV2.java
+++ b/chat/src/main/java/com/team15gijo/chat/domain/repository/v2/ChatRoomRepositoryV2.java
@@ -5,6 +5,6 @@ import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ChatRoomRepositoryV2 extends JpaRepository<ChatRoomV2, UUID>, ChatRoomQueryDslRepositoryV2Custom {
+public interface ChatRoomRepositoryV2 extends JpaRepository<ChatRoomV2, UUID> {
     Optional<ChatRoomV2> findByChatRoomIdAndDeletedAtNull(UUID chatRoomId);
 }

--- a/chat/src/main/java/com/team15gijo/chat/infrastructure/config/RegexUtils.java
+++ b/chat/src/main/java/com/team15gijo/chat/infrastructure/config/RegexUtils.java
@@ -1,0 +1,13 @@
+package com.team15gijo.chat.infrastructure.config;
+
+import java.util.regex.Pattern;
+
+public class RegexUtils {
+    public static String escapeRegex(String input) {
+        if (input == null || input.isEmpty()) {
+            return input;
+        }
+        Pattern specialCharacters = Pattern.compile("[\\.\\*\\+\\?\\^\\$\\{\\}\\[\\]\\\\|\\(\\)]");
+        return specialCharacters.matcher(input).replaceAll("\\\\$0");
+    }
+}

--- a/chat/src/main/java/com/team15gijo/chat/infrastructure/utils/RegexUtils.java
+++ b/chat/src/main/java/com/team15gijo/chat/infrastructure/utils/RegexUtils.java
@@ -1,4 +1,4 @@
-package com.team15gijo.chat.infrastructure.config;
+package com.team15gijo.chat.infrastructure.utils;
 
 import java.util.regex.Pattern;
 

--- a/chat/src/main/java/com/team15gijo/chat/presentation/controller/v2/ChatControllerV2.java
+++ b/chat/src/main/java/com/team15gijo/chat/presentation/controller/v2/ChatControllerV2.java
@@ -1,5 +1,7 @@
 package com.team15gijo.chat.presentation.controller.v2;
 
+import static com.team15gijo.chat.domain.exception.ChatDomainExceptionCode.SENT_AT_DATETIME_PARSE;
+
 import com.team15gijo.chat.application.dto.v2.ChatMessageResponseDtoV2;
 import com.team15gijo.chat.application.dto.v2.ChatRoomResponseDtoV2;
 import com.team15gijo.chat.application.service.impl.v2.ChatServiceImplV2;
@@ -9,6 +11,7 @@ import com.team15gijo.chat.presentation.dto.v2.ChatMessageRequestDtoV2;
 import com.team15gijo.chat.presentation.dto.v2.ChatRoomRequestDtoV2;
 import com.team15gijo.common.annotation.RoleGuard;
 import com.team15gijo.common.dto.ApiResponse;
+import com.team15gijo.common.exception.CustomException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
@@ -268,7 +271,9 @@ public class ChatControllerV2 {
         @RequestHeader("X-User-Id") Long userId
     ) {
         log.info("[ChatControllerV2] searchMessages 메소드 시작");
-        Sort.Direction direction = sortDirection.equalsIgnoreCase("desc") ? Sort.Direction.DESC : Sort.Direction.ASC;
+        Sort.Direction direction = sortDirection.equalsIgnoreCase("desc")
+            ? Sort.Direction.DESC
+            : Sort.Direction.ASC;
         log.info(">> direction={}", direction);
         Pageable pageable = PageRequest.of(page, size, Sort.by(direction, sortField));
 
@@ -283,7 +288,7 @@ public class ChatControllerV2 {
                 log.info(">> parsedSentAt: {}", parsedSentAt);
             } catch (DateTimeParseException e) {
                 log.warn(">> sentAt 형식이 유효하지 않습니다. 'yyyy-MM-dd' 형식이어야 합니다. 입력값: {}", sentAt);
-                parsedSentAt = null; // 유효하지 않으면 무시
+                throw new CustomException(SENT_AT_DATETIME_PARSE);
             }
         }
         log.info(">> messageContent: {}", messageContent);

--- a/chat/src/main/resources/application.yml
+++ b/chat/src/main/resources/application.yml
@@ -42,19 +42,19 @@ spring:
       password: ${REDIS_PASSWORD}
 
 server:
-  port: ${CHAT_SEVER_PORT}
+  port: ${CHAT_SERVER_PORT}
 
 eureka:
   client:
     register-with-eureka: true
     fetch-registry: true
     service-url:
-      defaultZone: http://localhost:${EUREKA_SEVER_PORT}/eureka/
+      defaultZone: http://localhost:${EUREKA_SERVER_PORT}/eureka/
 
 management:
   zipkin:
     tracing:
-      endpoint: "http://localhost:${ZIPKIN_SEVER_PORT}/api/v2/spans"
+      endpoint: "http://localhost:${ZIPKIN_SERVER_PORT}/api/v2/spans"
   tracing:
     sampling:
       probability: 1.0
@@ -71,6 +71,8 @@ management:
 logging:
   level:
     com.team15gijo.chat.presentation.handler: DEBUG
+    org.springframework.web.socket: DEBUG
+    org.springframework.messaging: DEBUG
 
 feign:
   client:


### PR DESCRIPTION
# 💡 PR Summary - 날짜별/텍스트별 메시지 검색(queryDSL 적용)

<!-- 어떤 작업에 대한 PR 인지 위 주석을 대신하여 적어주세요 -->

### PR 타입

- [X] 신규 기능 추가/수정
- [ ] 버그 수정
- [ ] 리팩토링
- [X] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)
- [ ] release

</br>

### 📝 Description
---

<!-- 어떤 작업을 했는지 간단하게 적어주세요 -->
- **as-is**
    - 메시지 검색 구현X

- **to-be**
    - 날짜별/텍스트별 메시지 검색(queryDSL 적용)

</br>

### 📚 Etc

---

<!-- 작업 중 특이사항이 생기면 적어주세요 -->
- Query Params 중, `sentAt` 또는 `messageContent`는 선택적으로 적용 가능
- `sentAt='2025-04-21'` 와 같이 yyyy-mm-dd 형식으로 조회 가능
- `messageContent` 입력된 일부 텍스트로 조회도 가능
<img width="489" alt="스크린샷 2025-04-21 오후 1 05 34" src="https://github.com/user-attachments/assets/3897514a-0f27-44ee-a119-0bdb7c082855" />

</br>

### 관련 이슈

---
#121 
<!-- #12 #이슈번호(PR에 해당하는 이슈번호 작성해주세요) -->  

</br>
</br>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an API endpoint to search chat messages by chat room with filters for sent date and message content, including pagination and sorting.
  - Introduced support for advanced message search using escaped regex patterns for safe and flexible filtering.

- **Bug Fixes**
  - Corrected environment variable names for server ports in the configuration file.

- **Chores**
  - Enhanced logging for WebSocket and messaging components.
  - Improved build process to support QueryDSL and annotation processing.
  - Added a new exception code for invalid date format in search requests.

- **Refactor**
  - Streamlined repository interfaces and removed unused custom repository classes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->