### PR TITLE
feat: 댓글에 redis 와 kafka 를 적용

### DIFF
--- a/comment/build.gradle
+++ b/comment/build.gradle
@@ -24,6 +24,10 @@ ext {
 dependencies {
 	implementation project(':common')
 
+
+	//redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
 	//prometheus
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	runtimeOnly 'io.micrometer:micrometer-registry-prometheus'

--- a/comment/src/main/java/com/team15gijo/comment/infrastructure/config/CommentApplicationKafkaConfig.java
+++ b/comment/src/main/java/com/team15gijo/comment/infrastructure/config/CommentApplicationKafkaConfig.java
@@ -1,5 +1,6 @@
-package com.team15gijo.comment.infrastructure.kafka;
+package com.team15gijo.comment.infrastructure.config;
 
+import com.team15gijo.comment.infrastructure.kafka.dto.CommentCountEventDto;
 import com.team15gijo.comment.infrastructure.kafka.dto.CommentNotificationEventDto;
 import java.util.HashMap;
 import java.util.Map;
@@ -33,6 +34,20 @@ public class CommentApplicationKafkaConfig {
         configProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
         configProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
         return new DefaultKafkaProducerFactory<>(configProps);
+    }
+
+    @Bean
+    public KafkaTemplate<String, CommentCountEventDto> countTemplate() {
+        return new KafkaTemplate<>(countProducerFactory());
+    }
+
+    @Bean
+    public ProducerFactory<String, CommentCountEventDto> countProducerFactory() {
+        Map<String,Object> props = new HashMap<>();
+        props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG,    "localhost:9092");
+        props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG,  StringSerializer.class);
+        props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+        return new DefaultKafkaProducerFactory<>(props);
     }
 
 }

--- a/comment/src/main/java/com/team15gijo/comment/infrastructure/config/RedisConfig.java
+++ b/comment/src/main/java/com/team15gijo/comment/infrastructure/config/RedisConfig.java
@@ -1,0 +1,20 @@
+package com.team15gijo.comment.infrastructure.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new StringRedisSerializer());
+        return template;
+    }
+}

--- a/comment/src/main/java/com/team15gijo/comment/infrastructure/kafka/dto/CommentCountEventDto.java
+++ b/comment/src/main/java/com/team15gijo/comment/infrastructure/kafka/dto/CommentCountEventDto.java
@@ -1,0 +1,11 @@
+package com.team15gijo.comment.infrastructure.kafka.dto;
+
+import lombok.*;
+
+import java.util.UUID;
+
+@Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder
+public class CommentCountEventDto {
+    private UUID postId;
+    private int  delta;   // +1 or -1
+}

--- a/comment/src/main/java/com/team15gijo/comment/infrastructure/kafka/service/KafkaProducerService.java
+++ b/comment/src/main/java/com/team15gijo/comment/infrastructure/kafka/service/KafkaProducerService.java
@@ -1,5 +1,6 @@
 package com.team15gijo.comment.infrastructure.kafka.service;
 
+import com.team15gijo.comment.infrastructure.kafka.dto.CommentCountEventDto;
 import com.team15gijo.comment.infrastructure.kafka.dto.CommentNotificationEventDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.kafka.core.KafkaTemplate;
@@ -10,9 +11,15 @@ import org.springframework.stereotype.Service;
 public class KafkaProducerService {
 
     private final KafkaTemplate<String, CommentNotificationEventDto> kafkaTemplate;
+    private final KafkaTemplate<String, CommentCountEventDto>       countTemplate;
 
     public void sendCommentCreate(CommentNotificationEventDto event) {
         kafkaTemplate.send("COMMENT", event);
+    }
+
+
+    public void sendCommentCount(CommentCountEventDto evt) {
+        countTemplate.send("COMMENT_COUNT_EVENTS", evt.getPostId().toString(), evt);
     }
 
 }

--- a/comment/src/main/resources/application.yml
+++ b/comment/src/main/resources/application.yml
@@ -25,10 +25,16 @@ spring:
     producer:
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
       value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+      acks: 0
     consumer:
       key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
       value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
       auto-offset-reset: earliest
+  data:
+    redis:
+      host: localhost
+      port: 6379
+      password: ${REDIS_PASSWORD}
 
 eureka:
   client:

--- a/post/src/main/java/com/team15gijo/post/domain/repository/v2/PostRepositoryV2.java
+++ b/post/src/main/java/com/team15gijo/post/domain/repository/v2/PostRepositoryV2.java
@@ -7,33 +7,37 @@ import java.util.UUID;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-public interface PostRepositoryV2 extends JpaRepository<PostV2, UUID>,
-        PostQueryDslRepositoryV2Custom {
+public interface PostRepositoryV2 extends JpaRepository<PostV2, UUID>, PostQueryDslRepositoryV2Custom {
     List<PostV2> findByRegionAndCreatedAtBeforeOrderByCreatedAtDesc(String region, LocalDateTime cursor, PageRequest of);
 
+    @Modifying
+    @Query("UPDATE PostV2 p SET p.commentCount = p.commentCount + :delta WHERE p.postId = :postId")
+    int incrementCommentCount(@Param("postId") UUID postId,
+            @Param("delta") int delta);
     /**
      *  검색에서 쓰는 쿼리
      */
-//    @Query("""
-//        SELECT DISTINCT p FROM PostV2 p
-//        LEFT JOIN p.hashtags h
-//        WHERE p.region = :region
-//          AND (
-//                LOWER(p.username) LIKE LOWER(:keyword)
-//             OR LOWER(p.postContent) LIKE LOWER(:keyword)
-//          )
-//          AND p.createdAt < :cursor
-//        ORDER BY p.createdAt DESC
-//    """)
-//    List<PostV2> findPostByKeyword(
-//            @Param("keyword") String keyword,
-//            @Param("region") String region,
-//            @Param("cursor") LocalDateTime cursor,
-//            Pageable pageable
-//    );
+    @Query("""
+        SELECT DISTINCT p FROM PostV2 p
+        LEFT JOIN p.hashtags h
+        WHERE p.region = :region
+          AND (
+                LOWER(p.username) LIKE LOWER(:keyword)
+             OR LOWER(p.postContent) LIKE LOWER(:keyword)
+          )
+          AND p.createdAt < :cursor
+        ORDER BY p.createdAt DESC
+    """)
+    List<PostV2> findPostByKeyword(
+            @Param("keyword") String keyword,
+            @Param("region") String region,
+            @Param("cursor") LocalDateTime cursor,
+            Pageable pageable
+    );
 
 
 

--- a/post/src/main/java/com/team15gijo/post/infrastructure/config/ProducerApplicationKafkaConfig.java
+++ b/post/src/main/java/com/team15gijo/post/infrastructure/config/ProducerApplicationKafkaConfig.java
@@ -1,5 +1,6 @@
 package com.team15gijo.post.infrastructure.config;
 
+import com.team15gijo.post.infrastructure.kafka.dto.v1.CommentCountEventDto;
 import com.team15gijo.post.infrastructure.kafka.dto.v1.FeedEventDto;
 import java.util.HashMap;
 import java.util.Map;
@@ -17,7 +18,7 @@ public class ProducerApplicationKafkaConfig {
     @Bean
     public ProducerFactory<String, FeedEventDto> producerFactory() {
         Map<String, Object> configProps = new HashMap<>();
-        configProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        configProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092"); // 하드코딩 아니고 주입받아야한다.
         configProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
         configProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
         return new DefaultKafkaProducerFactory<>(configProps);
@@ -26,5 +27,19 @@ public class ProducerApplicationKafkaConfig {
     @Bean
     public KafkaTemplate<String, FeedEventDto> kafkaTemplate() {
         return new KafkaTemplate<>(producerFactory());
+    }
+
+    // 2) CommentCountEventDto 용 KafkaTemplate
+    @Bean
+    public ProducerFactory<String, CommentCountEventDto> commentCountProducerFactory() {
+        Map<String,Object> props = new HashMap<>();
+        props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG,    "localhost:9092");
+        props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG,  StringSerializer.class);
+        props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+        return new DefaultKafkaProducerFactory<>(props);
+    }
+    @Bean
+    public KafkaTemplate<String, CommentCountEventDto> commentCountKafkaTemplate() {
+        return new KafkaTemplate<>(commentCountProducerFactory());
     }
 }

--- a/post/src/main/java/com/team15gijo/post/infrastructure/kafka/dto/v1/CommentCountEventDto.java
+++ b/post/src/main/java/com/team15gijo/post/infrastructure/kafka/dto/v1/CommentCountEventDto.java
@@ -1,0 +1,14 @@
+package com.team15gijo.post.infrastructure.kafka.dto.v1;
+
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder
+public class CommentCountEventDto {
+    private UUID postId;
+    private int  delta;   // +1 or -1
+}

--- a/post/src/main/java/com/team15gijo/post/infrastructure/kafka/service/v1/CommentCountConsumer.java
+++ b/post/src/main/java/com/team15gijo/post/infrastructure/kafka/service/v1/CommentCountConsumer.java
@@ -1,0 +1,42 @@
+
+package com.team15gijo.post.infrastructure.kafka.service.v1;
+
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.team15gijo.post.domain.repository.v2.PostRepositoryV2;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CommentCountConsumer {
+
+    private final ObjectMapper objectMapper;
+    private final PostRepositoryV2 postRepo;
+    private final RedisTemplate<String,Object> redisTemplate;
+
+    @KafkaListener(topics   = "COMMENT_COUNT_EVENTS", groupId  = "post-comment-count-flusher")
+    @Transactional
+    public void handle(String message) throws JsonProcessingException {
+        // 메시지를 JsonNode로 읽어들임
+        JsonNode root = objectMapper.readTree(message);
+
+        // 필요한 필드(postId, delta) 추출
+        UUID postId = UUID.fromString(root.get("postId").asText());
+        int delta  = root.get("delta").asInt();
+
+        // 경량 쿼리로 DB 업데이트
+        postRepo.incrementCommentCount(postId, delta);
+
+        //  Redis buffer 클리어
+        String key = postId.toString();
+        redisTemplate.opsForHash().delete("comments:buffer", key);
+        redisTemplate.opsForSet().remove("comments:dirty-keys", key);
+    }
+}

--- a/post/src/main/java/com/team15gijo/post/infrastructure/kafka/service/v1/ProducerService.java
+++ b/post/src/main/java/com/team15gijo/post/infrastructure/kafka/service/v1/ProducerService.java
@@ -1,5 +1,6 @@
 package com.team15gijo.post.infrastructure.kafka.service.v1;
 
+import com.team15gijo.post.infrastructure.kafka.dto.v1.CommentCountEventDto;
 import com.team15gijo.post.infrastructure.kafka.dto.v1.FeedEventDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.kafka.core.KafkaTemplate;
@@ -10,9 +11,15 @@ import org.springframework.stereotype.Service;
 public class ProducerService {
 
     private final KafkaTemplate<String, FeedEventDto> postCreadtedkafkaTemplate;
+    private final KafkaTemplate<String, CommentCountEventDto>    commentCountKafkaTemplate;
 
 
     public void sendMessage(String topic , String key, FeedEventDto event) {
         postCreadtedkafkaTemplate.send(topic, key, event);
+    }
+
+    /** 댓글 카운트 전용 event 발행 */
+    public void sendCommentCountMessage(String topic, String key, CommentCountEventDto event) {
+        commentCountKafkaTemplate.send(topic, key, event);
     }
 }

--- a/post/src/main/java/com/team15gijo/post/infrastructure/kafka/util/KafkaUtil.java
+++ b/post/src/main/java/com/team15gijo/post/infrastructure/kafka/util/KafkaUtil.java
@@ -1,6 +1,7 @@
 package com.team15gijo.post.infrastructure.kafka.util;
 
 import com.team15gijo.post.domain.model.v2.PostV2;
+import com.team15gijo.post.infrastructure.kafka.dto.v1.CommentCountEventDto;
 import com.team15gijo.post.infrastructure.kafka.dto.v1.CommentCreatedEventDto;
 import com.team15gijo.post.infrastructure.kafka.dto.v1.CommentDeletedEventDto;
 import com.team15gijo.post.infrastructure.kafka.dto.v1.EventType;
@@ -21,6 +22,8 @@ public class KafkaUtil {
 
     private final ProducerService producerService;
 
+    private static final String COMMENT_COUNT_EVENTS_TOPIC = "COMMENT_COUNT_EVENTS";
+
     /**
      * kafka 이벤트 발행
      */
@@ -28,6 +31,15 @@ public class KafkaUtil {
         if (topic == null || post == null || eventType == null) return;
         FeedEventDto feedEventDto = createEventMessageByType(eventType, post);
         producerService.sendMessage(topic, null, feedEventDto);
+    }
+
+    /** 댓글 수 증분/감소 전용 비동기 이벤트 발행 */
+    public void sendCommentCountEvent(CommentCountEventDto evt) {
+        producerService.sendCommentCountMessage(
+                COMMENT_COUNT_EVENTS_TOPIC,
+                evt.getPostId().toString(),
+                evt
+        );
     }
 
     public FeedEventDto createEventMessageByType(EventType eventType, PostV2 post) {

--- a/post/src/main/resources/application.yml
+++ b/post/src/main/resources/application.yml
@@ -33,6 +33,7 @@ spring:
     producer:
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
       value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+      acks: 0
   data:
     redis:
       host: localhost


### PR DESCRIPTION
# 💡 PR Summary - <!--{ 작업 내용 }-->

<!-- 어떤 작업에 대한 PR 인지 위 주석을 대신하여 적어주세요 -->

### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [x] 신규 기능 추가/수정
- [ ] 버그 수정
- [ ] 리팩토링
- [x] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)
- [ ] release

</br>

### 📝 Description

---

<!-- 어떤 작업을 했는지 간단하게 적어주세요 -->
- **as-is**
    -  댓글 작성시
      - 동기 HTTP 호출
        - postClient.exists + postClient.addCommentCount 
      - 동기 DB 쓰기
        - 댓글 INSERT + 게시글 comment_count UPDATE  

- **to-be**
    - 댓글 작성시
      - 동기 HTTP 호출
        - postClient.exists + postClient.addCommentCount → exists 1회
      - 동기 DB 쓰기
        - 댓글 INSERT + 게시글 comment_count UPDATE  → 댓글 INSERT 1회
      - 메모리 연산: Redis 해시 증분(HINCRBY)과 dirty-set 추가(SADD) 각 1회
      - Kafka 발행: 알림/비즈니스 이벤트 1회 
      
      로 변경되었습니다.

</br>

### 📚 Etc

---

<!-- 작업 중 특이사항이 생기면 적어주세요 -->
- 그런데, db insert 와 postClient.exists 가 성능에 큰 부분을 차지하고 있고, redis , kafka 역시 시간이 필요하다보니 성능적인 개선이 생각보다 크게 일어나지는 않았습니다. 

</br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - 댓글 수에 대한 Redis 캐싱 및 버퍼링 도입으로 댓글 처리 성능 및 확장성 향상
  - Kafka 이벤트를 활용한 비동기 댓글 수 업데이트로 서비스 간 최종 일관성 확보
  - 댓글 수 변경을 실시간으로 처리하는 신규 이벤트 타입 및 리스너 구현

- **Bug Fixes**
  - 키워드 기반 게시글 검색 기능 복원

- **Chores**
  - Redis 지원을 위한 설정 추가 및 Kafka 프로듀서 응답 설정(acks) 조정
<!-- end of auto-generated comment: release notes by coderabbit.ai -->