### PR TITLE
Feature/v2/121 chat kafka :  버전 분리로 인한 v1 웹소켓 메시지 전송 오류 해결

### DIFF
--- a/chat/src/main/java/com/team15gijo/chat/application/dto/v1/ChatMessageResponseDto.java
+++ b/chat/src/main/java/com/team15gijo/chat/application/dto/v1/ChatMessageResponseDto.java
@@ -2,6 +2,7 @@ package com.team15gijo.chat.application.dto.v1;
 
 import com.team15gijo.chat.domain.model.v1.ConnectionType;
 import java.time.LocalDateTime;
+import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -13,6 +14,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class ChatMessageResponseDto {
     private String id;
+    private UUID chatRoomId;
     private Long senderId;
     private Long receiverId;
     private String receiverNickname;

--- a/chat/src/main/java/com/team15gijo/chat/presentation/config/v1/WebSocketConfig.java
+++ b/chat/src/main/java/com/team15gijo/chat/presentation/config/v1/WebSocketConfig.java
@@ -35,8 +35,8 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     @Override
     public void configureMessageBroker(MessageBrokerRegistry registry) {
         // 메시지 구독 주소 prefix: /topic, /queue
-        registry.enableSimpleBroker("/topic/v1");
+        registry.enableSimpleBroker("/topic");
         // 클라이언트에서 메시지 보낼 때 /app으로 시작하면 @MessageMapping 메서드로 라우팅
-        registry.setApplicationDestinationPrefixes("/app/v1");
+        registry.setApplicationDestinationPrefixes("/app");
     }
 }

--- a/chat/src/main/java/com/team15gijo/chat/presentation/config/v2/WebSocketConfigV2.java
+++ b/chat/src/main/java/com/team15gijo/chat/presentation/config/v2/WebSocketConfigV2.java
@@ -35,8 +35,8 @@ public class WebSocketConfigV2 implements WebSocketMessageBrokerConfigurer {
     @Override
     public void configureMessageBroker(MessageBrokerRegistry registry) {
         // 메시지 구독 주소 prefix: /topic, /queue
-        registry.enableSimpleBroker("/topic/v2");
+        registry.enableSimpleBroker("/topic");
         // 클라이언트에서 메시지 보낼 때 /app으로 시작하면 @MessageMapping 메서드로 라우팅
-        registry.setApplicationDestinationPrefixes("/app/v2");
+        registry.setApplicationDestinationPrefixes("/app");
     }
 }

--- a/chat/src/main/java/com/team15gijo/chat/presentation/controller/v1/ChatControllerV1.java
+++ b/chat/src/main/java/com/team15gijo/chat/presentation/controller/v1/ChatControllerV1.java
@@ -36,10 +36,10 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 
 @Slf4j
-@Controller("chatController")
+@Controller("chatControllerV1")
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/chats")
-public class ChatController {
+public class ChatControllerV1 {
 
     private final ChatService chatService;
 
@@ -210,7 +210,6 @@ public class ChatController {
      * @param headerAccessor : sessionID 추출
      */
     @MessageMapping("/v1/chat/connect/{chatRoomId}/{senderId}")
-    @SendTo("/topic/v1/chat/{chatRoomId}")
     public void connectChatRoom(
         @DestinationVariable UUID chatRoomId,
         @DestinationVariable Long senderId,

--- a/chat/src/main/java/com/team15gijo/chat/presentation/controller/v2/ChatControllerV2.java
+++ b/chat/src/main/java/com/team15gijo/chat/presentation/controller/v2/ChatControllerV2.java
@@ -216,7 +216,7 @@ public class ChatControllerV2 {
      * Redis key(chatRoomId:senderId)-value(SessionID, senderId, chatRoomId)로 변경
      * @param headerAccessor : sessionID 추출
      */
-    @MessageMapping("/chat/connect/{chatRoomId}/{senderId}")
+    @MessageMapping("/v2/chat/connect/{chatRoomId}/{senderId}")
     public ResponseEntity<ApiResponse<String>> connectChatRoom(
         @DestinationVariable UUID chatRoomId,
         @DestinationVariable Long senderId,
@@ -232,7 +232,7 @@ public class ChatControllerV2 {
      * "/topic"을 구독하는 서버에서 실시간 메시지 송수신 가능
      * "/app" 시작하는 경로 stomp 메시지 전송하면 @MessageMapping 으로 연결
      */
-    @MessageMapping("/chat/{chatRoomId}")
+    @MessageMapping("/v2/chat/{chatRoomId}")
     public ResponseEntity<ApiResponse<String>> sendMessage(
         @RequestBody ChatMessageRequestDtoV2 requestDto,
         SimpMessageHeaderAccessor headerAccessor

--- a/chat/src/main/resources/templates/v1/index.html
+++ b/chat/src/main/resources/templates/v1/index.html
@@ -53,7 +53,7 @@
       fetch(`/api/v1/chats/validate/nickname/${receiverNickname}`)
         .then(response => response.json())
         .then(data => {
-          if (data.data.receiverId !== null) {
+          if (data.data.receiverId != null) {
             console.log("receiverNickname 유효성 검증 성공");
             receiverId = data.data.receiverId;
             console.log("[수신자 ID] receiverId=" + receiverId);
@@ -69,7 +69,7 @@
               console.log('소켓 Connected: ' + frame);
 
               // connect 엔드포인트로 메시지 전송하여 Redis 저장
-              stompClient.send("/app/v1/chat/connect/" + chatRoomId + "/" + senderId, {},
+              stompClient.send(`/app/v1/chat/connect/${chatRoomId}/${senderId}`, {},
                 senderId + "님이 입장하였습니다."
               );
 
@@ -102,12 +102,12 @@
               });
 
               // 실시간 채팅 메시지 전송 구독
-              stompClient.subscribe('/topic/v1/chat/' + chatRoomId, function (message) {
+              stompClient.subscribe(`/topic/v1/chat/${chatRoomId}`, function (message) {
                 showMessage((JSON.parse(message.body)));
               });
 
               // 처음 채팅방 입장 메시지 구독
-              stompClient.subscribe('/topic/v1/chat/enter/' + chatRoomId, function (message) {
+              stompClient.subscribe(`/topic/v1/chat/enter/${chatRoomId}`, function (message) {
                 showMessage(JSON.parse(message.body));
               });
             }, function (error) {
@@ -116,8 +116,8 @@
             });
           } else {
             // 수신자(유저)닉네임이 채팅방 참여자인지 유효하지 않을 때 오류 표시
-            console.log("receiverNickname 유효성 검증하여 receiverId가 null 입니다.");
-            alert('receiverNickname 유효성 검증하여 receiverId가 null 입니다. 다시 확인해주세요.');
+            console.log("receiverNickname(" + receiverNickname + ")이 유효하지 않아 receiverId가 null 입니다. ");
+            alert('받는 사용자 닉네임(' + receiverNickname + ')이 유효하지 않습니다. 다시 확인해주세요.');
           }
         })
       .catch(error => {
@@ -155,7 +155,7 @@
       if(isConnected) {
         const senderId = parseInt(document.getElementById('senderId').value); // 문자열을 숫자로 변환
         const message = document.getElementById('message').value;
-        stompClient.send("/app/v1/chat/" + chatRoomId, {}, JSON.stringify({ // messageMapping 경로 사용
+        stompClient.send(`/app/v1/chat/${chatRoomId}`, {}, JSON.stringify({ // messageMapping 경로 사용
           'chatRoomId': chatRoomId,
           'senderId': senderId,
           'receiverId' : receiverId,
@@ -195,7 +195,7 @@
 <body>
 <div>
   <label>ChatRoom ID:</label>
-  <input type="text" id="chatRoomId" value="f38106f7-8fe7-4351-8eaf-199525b67e9a" />
+  <input type="text" id="chatRoomId" value="d1b8b55d-fc9b-4e14-b598-b620706becbc" />
 </div>
 <div>
   <label>SenderId(발송자 ID) :</label>
@@ -203,7 +203,7 @@
 </div>
 <div>
   <label>Receiver Nickname(상대방/수신자 닉네임) :</label>
-  <input type="text" id="receiverNickname" value="nickname1" />
+  <input type="text" id="receiverNickname" value="testnick22" />
 </div>
 <div>
   <label>Message:</label>


### PR DESCRIPTION
# 💡 PR Summary - v1 웹소켓 메시지 전송 오류 해결

<!-- 어떤 작업에 대한 PR 인지 위 주석을 대신하여 적어주세요 -->

### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [X] 신규 기능 추가/수정
- [X] 버그 수정
- [ ] 리팩토링
- [ ] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)
- [ ] release

</br>

### 📝 Description

---

<!-- 어떤 작업을 했는지 간단하게 적어주세요 -->
- **as-is**
    - 버전 분리로 인해 v2는 동작하고, 기존의 v1 메시지 전송이 되지 않음

- **to-be**
    - 웹소켓 설정 `registry.setApplicationDestinationPrefixes("/app")` 변경으로 v1과 v2 모두 실시간 채팅 메시지 전송 가능

</br>

### 📚 Etc

---

<!-- 작업 중 특이사항이 생기면 적어주세요 -->
- v1, v2 컨트롤러의 `@MessageMapping("/v1/chat/{chatRoomId}")` 어노테이션 경로 prefix 버전별 /v1, /v2 추가하여 미작동 오류 해결

</br>

### 관련 이슈

---
#121 
<!-- #12 #이슈번호(PR에 해당하는 이슈번호 작성해주세요) -->  

</br>
</br>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new field to chat messages to include the chat room ID.

- **Improvements**
  - Simplified and unified WebSocket message routing paths by removing version suffixes from broker and application destination prefixes.
  - Updated controller naming to reflect versioning more clearly.
  - Enhanced client chat interface with improved validation feedback and updated default values.
  - Refined WebSocket endpoint paths for better clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->