### PR TITLE
fix: 롤 가드 api 패턴 주소 변경

### DIFF
--- a/common/src/main/java/com/team15gijo/common/config/WebMvcConfig.java
+++ b/common/src/main/java/com/team15gijo/common/config/WebMvcConfig.java
@@ -16,10 +16,7 @@ public class WebMvcConfig implements WebMvcConfigurer {
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(roleGuardInterceptor)
-                .addPathPatterns("/api/v1/users/**")
-                .addPathPatterns("/api/v1/feeds/**")
-                .addPathPatterns("/api/v1/notifications/**")
-                .addPathPatterns("/api/v1/chats/**")
-                .addPathPatterns("/api/v2/follows/**");
+                .addPathPatterns("/api/**")
+                .excludePathPatterns("/api/v1/auth/**");
     }
 }

--- a/common/src/main/java/com/team15gijo/common/interceptor/RoleGuardInterceptor.java
+++ b/common/src/main/java/com/team15gijo/common/interceptor/RoleGuardInterceptor.java
@@ -21,6 +21,8 @@ public class RoleGuardInterceptor implements HandlerInterceptor {
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response,
             Object handler) throws Exception {
 
+        log.info("롤 가드 인터셉터 실행!");
+
         //컨트롤러 mvc 매서드 아닌 경우 통과
         if (!(handler instanceof HandlerMethod handlerMethod)) {
             return true;


### PR DESCRIPTION
# 💡 PR Summary - 롤 가드 api 패턴 주소 변경

<!-- 어떤 작업에 대한 PR 인지 위 주석을 대신하여 적어주세요 -->

### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [ ] 신규 기능 추가/수정
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)
- [ ] release

</br>

### 📝 Description

---

<!-- 어떤 작업을 했는지 간단하게 적어주세요 -->
- **as-is**
    - 롤가드 검사 api 주소 직접 지정

- **to-be**
    - 롤가드 어노테이션 없으면 어차피 검사 하지 않음 -> 따라서 모든 api 롤가드 인터셉터에 걸리게 넣음

</br>

### 📚 Etc

---

<!-- 작업 중 특이사항이 생기면 적어주세요 -->
- (추가적인 설명이나 코멘트가 필요한 경우 여기에 작성)

</br>

### 관련 이슈

---

<!-- #12 #이슈번호(PR에 해당하는 이슈번호 작성해주세요) -->  

</br>
</br>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 인증 관련 경로(`/api/v1/auth/**`)를 제외하고 모든 API 경로(`/api/**`)에 역할 가드 인터셉터가 적용되도록 범위가 조정되었습니다.

- **스타일**
  - 역할 가드 인터셉터 실행 시 로그 메시지가 추가되어 동작 여부를 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->